### PR TITLE
Enable dynamic proxy port in OldReaderApi

### DIFF
--- a/lib/services/old_reader_api.dart
+++ b/lib/services/old_reader_api.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 class OldReaderApi {
   /// Busca favoritos (starred) via HTML web
   Future<String> getStarredItemsHtml({String? cookies}) async {
-    final url = Uri.parse('http://localhost:3000/proxy/posts/starred');
+    final url = Uri.parse('${getProxyBaseUrl()}/proxy/posts/starred');
     final headers = <String, String>{};
     if (cookies != null) headers['Cookie'] = cookies;
     final resp = await http.get(url, headers: headers);
@@ -250,13 +250,17 @@ class OldReaderApi {
     return await http.get(url, headers: _headers());
   }
 
+  // Porta padrão do proxy. Pode ser alterada em tempo de execução
+  static int _proxyPort = 3000;
+
   // Use o proxy local para evitar CORS no Flutter Web
-  // A porta é configurada pelo proxy_config.dart
+  // A baseUrl é construída dinamicamente a partir da porta configurada
   static String baseUrl = '${getProxyBaseUrl()}/proxy';
 
   // Permite mudar a porta do proxy em tempo de execução
   static void setProxyPort(int port) {
     // Atualiza a porta do proxy e a baseUrl
+    _proxyPort = port;
     baseUrl = '${getProxyBaseUrl()}/proxy';
     debugPrint('Proxy URL atualizada para: $baseUrl');
   }
@@ -520,10 +524,12 @@ class OldReaderApi {
 
   static getProxyBaseUrl() {
     // Retorna a URL base do proxy configurado
+    // Usa a porta definida em [_proxyPort]
+    final host = 'http://localhost';
     if (kIsWeb) {
-      return 'http://localhost:3000'; // URL do proxy local para Flutter Web
+      return '$host:$_proxyPort'; // URL do proxy local para Flutter Web
     } else {
-      return 'http://localhost:3000'; // URL do proxy local para Flutter Mobile/Desktop
+      return '$host:$_proxyPort'; // URL do proxy local para Flutter Mobile/Desktop
     }
   }
 }


### PR DESCRIPTION
## Summary
- Allow configuring proxy port by storing `_proxyPort`
- Update `setProxyPort` to rebuild base URL using provided port
- Use dynamic proxy URL for starred items and base URL calculation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689669ddd03483298554c869c0f747f2