### PR TITLE
chore: require env vars for login test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Para gerenciar os logs do proxy, use:
 
 Este script permite visualizar, limpar e arquivar os logs do servidor proxy.
 
+## Testes
+
+Este repositório inclui testes automatizados de login utilizando o [Playwright](https://playwright.dev).
+Para executá-los, é necessário definir as variáveis de ambiente `the_old_reader_email` e `the_old_reader_password`
+com as credenciais da sua conta:
+
+```sh
+export the_old_reader_email="SEU_EMAIL"
+export the_old_reader_password="SUA_SENHA"
+npx playwright test
+```
+
+Se as variáveis não estiverem definidas, o teste será ignorado.
+
 ## Próximos passos
 - Implementar autenticação OAuth
 - Listar feeds e artigos

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect } from '@playwright/test';
 
+/**
+ * Este teste requer as variáveis de ambiente
+ * `the_old_reader_email` e `the_old_reader_password`.
+ */
+const email = process.env.the_old_reader_email;
+const password = process.env.the_old_reader_password;
+
+test.skip(
+  !email || !password,
+  'Defina as variáveis de ambiente the_old_reader_email e the_old_reader_password para executar este teste',
+);
+
 test.use({ browserName: 'chromium' });
 
 test('Login com credenciais válidas', async ({ page }) => {
@@ -10,10 +22,11 @@ test('Login com credenciais válidas', async ({ page }) => {
   await expect(page.getByPlaceholder('Email')).toBeVisible();
 
   // Preenche login
-  await page.getByPlaceholder('Email').fill(process.env.the_old_reader_email || 'SEU_EMAIL');
-  await page.getByPlaceholder('Password').fill(process.env.the_old_reader_password || 'SUA_SENHA');
+  await page.getByPlaceholder('Email').fill(email!);
+  await page.getByPlaceholder('Password').fill(password!);
   await page.getByRole('button', { name: /log in/i }).click();
 
   // Aguarda tela principal
   await expect(page.getByText(/assinaturas|feeds|subscriptions/i)).toBeVisible();
+  await expect(page).toHaveURL(/reader/i);
 });


### PR DESCRIPTION
## Summary
- require environment variables for login test
- document test setup with required variables

## Testing
- `npx playwright test tests/login.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68966b24c91c8329ab045519df5dac1e