### PR TITLE
Fase 1: persistência local (WorkItem + drift)

### DIFF
--- a/lib/domain/repositories/work_item_repository.dart
+++ b/lib/domain/repositories/work_item_repository.dart
@@ -1,0 +1,35 @@
+import '../../models/article.dart';
+import '../triage_status.dart';
+import '../work_item.dart';
+
+/// Porta de persistência local dos [WorkItem]s. Implementações vivem em
+/// `lib/infrastructure/repositories/`; nada em `lib/domain` ou
+/// `lib/application` deve depender de drift/SQL diretamente.
+abstract class WorkItemRepository {
+  /// Query reativa por status — a base das filas (`Queue`/`QuerySpec` de
+  /// fases futuras começam como filtros sobre este stream).
+  Stream<List<WorkItem>> watchByStatus(List<TriageStatus> statuses);
+
+  /// Contagem reativa por status, para badges de fila.
+  Stream<int> watchCountByStatus(TriageStatus status);
+
+  Future<WorkItem?> byId(String id);
+
+  /// Ingestão: para cada [Article], cria um [WorkItem] novo se não existir
+  /// (status inicial `novo`), ou atualiza apenas o snapshot (título,
+  /// conteúdo, read/star) de um item já existente — nunca sobrescreve
+  /// status/tags/priority/notes definidos localmente pelo usuário.
+  Future<void> upsertFromArticles(List<Article> articles, String providerId);
+
+  Future<void> save(WorkItem item);
+
+  /// Atualiza apenas o status, validando a transição via
+  /// [isValidTriageTransition]. Lança [StateError] em transição inválida.
+  Future<void> changeStatus(String id, TriageStatus newStatus);
+
+  /// Remove itens concluídos/arquivados mais antigos que [cutoff].
+  /// Retorna o número de itens removidos.
+  Future<int> purgeOlderThan(DateTime cutoff, {List<TriageStatus>? statuses});
+
+  Future<void> close();
+}

--- a/lib/domain/triage_status.dart
+++ b/lib/domain/triage_status.dart
@@ -1,0 +1,64 @@
+/// Estado de triagem local de um [WorkItem], independente do estado
+/// read/unread do provider remoto.
+enum TriageStatus {
+  novo,
+  triado,
+  emAndamento,
+  concluido,
+  arquivado;
+
+  static TriageStatus fromName(String name) => TriageStatus.values.firstWhere(
+        (s) => s.name == name,
+        orElse: () => TriageStatus.novo,
+      );
+}
+
+/// Transições válidas da máquina de estados de triagem.
+///
+/// Regras podem pular etapas (ex.: `novo` -> `arquivado` direto); transições
+/// manuais do usuário devem respeitar este mapa.
+const Map<TriageStatus, Set<TriageStatus>> kTriageTransitions = {
+  TriageStatus.novo: {
+    TriageStatus.triado,
+    TriageStatus.emAndamento,
+    TriageStatus.concluido,
+    TriageStatus.arquivado,
+  },
+  TriageStatus.triado: {
+    TriageStatus.emAndamento,
+    TriageStatus.concluido,
+    TriageStatus.arquivado,
+    TriageStatus.novo,
+  },
+  TriageStatus.emAndamento: {
+    TriageStatus.triado,
+    TriageStatus.concluido,
+    TriageStatus.arquivado,
+  },
+  TriageStatus.concluido: {
+    TriageStatus.arquivado,
+    TriageStatus.emAndamento,
+  },
+  TriageStatus.arquivado: {
+    TriageStatus.novo,
+    TriageStatus.triado,
+  },
+};
+
+bool isValidTriageTransition(TriageStatus from, TriageStatus to) {
+  if (from == to) return true;
+  return kTriageTransitions[from]?.contains(to) ?? false;
+}
+
+enum Priority {
+  none,
+  low,
+  medium,
+  high,
+  urgent;
+
+  static Priority fromName(String name) => Priority.values.firstWhere(
+        (p) => p.name == name,
+        orElse: () => Priority.none,
+      );
+}

--- a/lib/domain/work_item.dart
+++ b/lib/domain/work_item.dart
@@ -1,0 +1,75 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/article.dart';
+import 'triage_status.dart';
+
+part 'work_item.freezed.dart';
+
+/// Identidade estável de um [WorkItem]: `{providerId}:{articleId}`.
+///
+/// O `Article` de um provider não tem identidade local persistente — este id
+/// é o que permite ao FeedFlow rastrear o mesmo artigo entre syncs.
+String workItemIdFor(String providerId, String articleId) => '$providerId:$articleId';
+
+/// Aggregate root do processamento local de artigos: o `Article` ingerido de
+/// um provider é apenas um DTO de entrada (snapshot); o `WorkItem` é quem
+/// carrega o estado de triagem, tags, prioridade e enriquecimentos, sempre
+/// independente do estado read/unread do provider remoto.
+@freezed
+class WorkItem with _$WorkItem {
+  const WorkItem._();
+
+  const factory WorkItem({
+    required String id,
+    required String providerId,
+    required String articleId,
+    required String feedId,
+    required String title,
+    String? author,
+    String? summary,
+    String? content,
+    String? url,
+    DateTime? published,
+    DateTime? updated,
+    @Default(TriageStatus.novo) TriageStatus status,
+    @Default(Priority.none) Priority priority,
+    @Default([]) List<String> tags,
+    @Default(false) bool isRead,
+    @Default(false) bool isStarred,
+    DateTime? snoozedUntil,
+    String? notes,
+    required DateTime ingestedAt,
+    required DateTime updatedAt,
+    DateTime? completedAt,
+  }) = _WorkItem;
+
+  /// Constrói um [WorkItem] novo a partir do snapshot de ingestão de um
+  /// [Article]. Usado pelo `upsertFromArticles` do repositório — em um
+  /// upsert de item já existente, apenas os campos de snapshot (título,
+  /// conteúdo, read/star) são atualizados; status/tags/priority locais
+  /// não são tocados (ver `WorkItemRepository.upsertFromArticles`).
+  factory WorkItem.fromArticle(Article article, String providerId) {
+    final now = DateTime.now();
+    return WorkItem(
+      id: workItemIdFor(providerId, article.id),
+      providerId: providerId,
+      articleId: article.id,
+      feedId: article.feedId,
+      title: article.title,
+      author: article.author,
+      summary: article.summary,
+      content: article.content,
+      url: article.url,
+      published: article.published,
+      updated: article.updated,
+      isRead: article.isRead,
+      isStarred: article.isStarred,
+      ingestedAt: now,
+      updatedAt: now,
+    );
+  }
+
+  bool get isSnoozed => snoozedUntil != null && snoozedUntil!.isAfter(DateTime.now());
+
+  bool get isActive => status != TriageStatus.concluido && status != TriageStatus.arquivado;
+}

--- a/lib/domain/work_item.freezed.dart
+++ b/lib/domain/work_item.freezed.dart
@@ -1,0 +1,645 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'work_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$WorkItem {
+  String get id => throw _privateConstructorUsedError;
+  String get providerId => throw _privateConstructorUsedError;
+  String get articleId => throw _privateConstructorUsedError;
+  String get feedId => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String? get author => throw _privateConstructorUsedError;
+  String? get summary => throw _privateConstructorUsedError;
+  String? get content => throw _privateConstructorUsedError;
+  String? get url => throw _privateConstructorUsedError;
+  DateTime? get published => throw _privateConstructorUsedError;
+  DateTime? get updated => throw _privateConstructorUsedError;
+  TriageStatus get status => throw _privateConstructorUsedError;
+  Priority get priority => throw _privateConstructorUsedError;
+  List<String> get tags => throw _privateConstructorUsedError;
+  bool get isRead => throw _privateConstructorUsedError;
+  bool get isStarred => throw _privateConstructorUsedError;
+  DateTime? get snoozedUntil => throw _privateConstructorUsedError;
+  String? get notes => throw _privateConstructorUsedError;
+  DateTime get ingestedAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+  DateTime? get completedAt => throw _privateConstructorUsedError;
+
+  /// Create a copy of WorkItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $WorkItemCopyWith<WorkItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WorkItemCopyWith<$Res> {
+  factory $WorkItemCopyWith(WorkItem value, $Res Function(WorkItem) then) =
+      _$WorkItemCopyWithImpl<$Res, WorkItem>;
+  @useResult
+  $Res call({
+    String id,
+    String providerId,
+    String articleId,
+    String feedId,
+    String title,
+    String? author,
+    String? summary,
+    String? content,
+    String? url,
+    DateTime? published,
+    DateTime? updated,
+    TriageStatus status,
+    Priority priority,
+    List<String> tags,
+    bool isRead,
+    bool isStarred,
+    DateTime? snoozedUntil,
+    String? notes,
+    DateTime ingestedAt,
+    DateTime updatedAt,
+    DateTime? completedAt,
+  });
+}
+
+/// @nodoc
+class _$WorkItemCopyWithImpl<$Res, $Val extends WorkItem>
+    implements $WorkItemCopyWith<$Res> {
+  _$WorkItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of WorkItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? providerId = null,
+    Object? articleId = null,
+    Object? feedId = null,
+    Object? title = null,
+    Object? author = freezed,
+    Object? summary = freezed,
+    Object? content = freezed,
+    Object? url = freezed,
+    Object? published = freezed,
+    Object? updated = freezed,
+    Object? status = null,
+    Object? priority = null,
+    Object? tags = null,
+    Object? isRead = null,
+    Object? isStarred = null,
+    Object? snoozedUntil = freezed,
+    Object? notes = freezed,
+    Object? ingestedAt = null,
+    Object? updatedAt = null,
+    Object? completedAt = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as String,
+            providerId:
+                null == providerId
+                    ? _value.providerId
+                    : providerId // ignore: cast_nullable_to_non_nullable
+                        as String,
+            articleId:
+                null == articleId
+                    ? _value.articleId
+                    : articleId // ignore: cast_nullable_to_non_nullable
+                        as String,
+            feedId:
+                null == feedId
+                    ? _value.feedId
+                    : feedId // ignore: cast_nullable_to_non_nullable
+                        as String,
+            title:
+                null == title
+                    ? _value.title
+                    : title // ignore: cast_nullable_to_non_nullable
+                        as String,
+            author:
+                freezed == author
+                    ? _value.author
+                    : author // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            summary:
+                freezed == summary
+                    ? _value.summary
+                    : summary // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            content:
+                freezed == content
+                    ? _value.content
+                    : content // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            url:
+                freezed == url
+                    ? _value.url
+                    : url // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            published:
+                freezed == published
+                    ? _value.published
+                    : published // ignore: cast_nullable_to_non_nullable
+                        as DateTime?,
+            updated:
+                freezed == updated
+                    ? _value.updated
+                    : updated // ignore: cast_nullable_to_non_nullable
+                        as DateTime?,
+            status:
+                null == status
+                    ? _value.status
+                    : status // ignore: cast_nullable_to_non_nullable
+                        as TriageStatus,
+            priority:
+                null == priority
+                    ? _value.priority
+                    : priority // ignore: cast_nullable_to_non_nullable
+                        as Priority,
+            tags:
+                null == tags
+                    ? _value.tags
+                    : tags // ignore: cast_nullable_to_non_nullable
+                        as List<String>,
+            isRead:
+                null == isRead
+                    ? _value.isRead
+                    : isRead // ignore: cast_nullable_to_non_nullable
+                        as bool,
+            isStarred:
+                null == isStarred
+                    ? _value.isStarred
+                    : isStarred // ignore: cast_nullable_to_non_nullable
+                        as bool,
+            snoozedUntil:
+                freezed == snoozedUntil
+                    ? _value.snoozedUntil
+                    : snoozedUntil // ignore: cast_nullable_to_non_nullable
+                        as DateTime?,
+            notes:
+                freezed == notes
+                    ? _value.notes
+                    : notes // ignore: cast_nullable_to_non_nullable
+                        as String?,
+            ingestedAt:
+                null == ingestedAt
+                    ? _value.ingestedAt
+                    : ingestedAt // ignore: cast_nullable_to_non_nullable
+                        as DateTime,
+            updatedAt:
+                null == updatedAt
+                    ? _value.updatedAt
+                    : updatedAt // ignore: cast_nullable_to_non_nullable
+                        as DateTime,
+            completedAt:
+                freezed == completedAt
+                    ? _value.completedAt
+                    : completedAt // ignore: cast_nullable_to_non_nullable
+                        as DateTime?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$WorkItemImplCopyWith<$Res>
+    implements $WorkItemCopyWith<$Res> {
+  factory _$$WorkItemImplCopyWith(
+    _$WorkItemImpl value,
+    $Res Function(_$WorkItemImpl) then,
+  ) = __$$WorkItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String providerId,
+    String articleId,
+    String feedId,
+    String title,
+    String? author,
+    String? summary,
+    String? content,
+    String? url,
+    DateTime? published,
+    DateTime? updated,
+    TriageStatus status,
+    Priority priority,
+    List<String> tags,
+    bool isRead,
+    bool isStarred,
+    DateTime? snoozedUntil,
+    String? notes,
+    DateTime ingestedAt,
+    DateTime updatedAt,
+    DateTime? completedAt,
+  });
+}
+
+/// @nodoc
+class __$$WorkItemImplCopyWithImpl<$Res>
+    extends _$WorkItemCopyWithImpl<$Res, _$WorkItemImpl>
+    implements _$$WorkItemImplCopyWith<$Res> {
+  __$$WorkItemImplCopyWithImpl(
+    _$WorkItemImpl _value,
+    $Res Function(_$WorkItemImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of WorkItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? providerId = null,
+    Object? articleId = null,
+    Object? feedId = null,
+    Object? title = null,
+    Object? author = freezed,
+    Object? summary = freezed,
+    Object? content = freezed,
+    Object? url = freezed,
+    Object? published = freezed,
+    Object? updated = freezed,
+    Object? status = null,
+    Object? priority = null,
+    Object? tags = null,
+    Object? isRead = null,
+    Object? isStarred = null,
+    Object? snoozedUntil = freezed,
+    Object? notes = freezed,
+    Object? ingestedAt = null,
+    Object? updatedAt = null,
+    Object? completedAt = freezed,
+  }) {
+    return _then(
+      _$WorkItemImpl(
+        id:
+            null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as String,
+        providerId:
+            null == providerId
+                ? _value.providerId
+                : providerId // ignore: cast_nullable_to_non_nullable
+                    as String,
+        articleId:
+            null == articleId
+                ? _value.articleId
+                : articleId // ignore: cast_nullable_to_non_nullable
+                    as String,
+        feedId:
+            null == feedId
+                ? _value.feedId
+                : feedId // ignore: cast_nullable_to_non_nullable
+                    as String,
+        title:
+            null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                    as String,
+        author:
+            freezed == author
+                ? _value.author
+                : author // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        summary:
+            freezed == summary
+                ? _value.summary
+                : summary // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        content:
+            freezed == content
+                ? _value.content
+                : content // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        url:
+            freezed == url
+                ? _value.url
+                : url // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        published:
+            freezed == published
+                ? _value.published
+                : published // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+        updated:
+            freezed == updated
+                ? _value.updated
+                : updated // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+        status:
+            null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                    as TriageStatus,
+        priority:
+            null == priority
+                ? _value.priority
+                : priority // ignore: cast_nullable_to_non_nullable
+                    as Priority,
+        tags:
+            null == tags
+                ? _value._tags
+                : tags // ignore: cast_nullable_to_non_nullable
+                    as List<String>,
+        isRead:
+            null == isRead
+                ? _value.isRead
+                : isRead // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        isStarred:
+            null == isStarred
+                ? _value.isStarred
+                : isStarred // ignore: cast_nullable_to_non_nullable
+                    as bool,
+        snoozedUntil:
+            freezed == snoozedUntil
+                ? _value.snoozedUntil
+                : snoozedUntil // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+        notes:
+            freezed == notes
+                ? _value.notes
+                : notes // ignore: cast_nullable_to_non_nullable
+                    as String?,
+        ingestedAt:
+            null == ingestedAt
+                ? _value.ingestedAt
+                : ingestedAt // ignore: cast_nullable_to_non_nullable
+                    as DateTime,
+        updatedAt:
+            null == updatedAt
+                ? _value.updatedAt
+                : updatedAt // ignore: cast_nullable_to_non_nullable
+                    as DateTime,
+        completedAt:
+            freezed == completedAt
+                ? _value.completedAt
+                : completedAt // ignore: cast_nullable_to_non_nullable
+                    as DateTime?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$WorkItemImpl extends _WorkItem {
+  const _$WorkItemImpl({
+    required this.id,
+    required this.providerId,
+    required this.articleId,
+    required this.feedId,
+    required this.title,
+    this.author,
+    this.summary,
+    this.content,
+    this.url,
+    this.published,
+    this.updated,
+    this.status = TriageStatus.novo,
+    this.priority = Priority.none,
+    final List<String> tags = const [],
+    this.isRead = false,
+    this.isStarred = false,
+    this.snoozedUntil,
+    this.notes,
+    required this.ingestedAt,
+    required this.updatedAt,
+    this.completedAt,
+  }) : _tags = tags,
+       super._();
+
+  @override
+  final String id;
+  @override
+  final String providerId;
+  @override
+  final String articleId;
+  @override
+  final String feedId;
+  @override
+  final String title;
+  @override
+  final String? author;
+  @override
+  final String? summary;
+  @override
+  final String? content;
+  @override
+  final String? url;
+  @override
+  final DateTime? published;
+  @override
+  final DateTime? updated;
+  @override
+  @JsonKey()
+  final TriageStatus status;
+  @override
+  @JsonKey()
+  final Priority priority;
+  final List<String> _tags;
+  @override
+  @JsonKey()
+  List<String> get tags {
+    if (_tags is EqualUnmodifiableListView) return _tags;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tags);
+  }
+
+  @override
+  @JsonKey()
+  final bool isRead;
+  @override
+  @JsonKey()
+  final bool isStarred;
+  @override
+  final DateTime? snoozedUntil;
+  @override
+  final String? notes;
+  @override
+  final DateTime ingestedAt;
+  @override
+  final DateTime updatedAt;
+  @override
+  final DateTime? completedAt;
+
+  @override
+  String toString() {
+    return 'WorkItem(id: $id, providerId: $providerId, articleId: $articleId, feedId: $feedId, title: $title, author: $author, summary: $summary, content: $content, url: $url, published: $published, updated: $updated, status: $status, priority: $priority, tags: $tags, isRead: $isRead, isStarred: $isStarred, snoozedUntil: $snoozedUntil, notes: $notes, ingestedAt: $ingestedAt, updatedAt: $updatedAt, completedAt: $completedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$WorkItemImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.providerId, providerId) ||
+                other.providerId == providerId) &&
+            (identical(other.articleId, articleId) ||
+                other.articleId == articleId) &&
+            (identical(other.feedId, feedId) || other.feedId == feedId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.author, author) || other.author == author) &&
+            (identical(other.summary, summary) || other.summary == summary) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.published, published) ||
+                other.published == published) &&
+            (identical(other.updated, updated) || other.updated == updated) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.priority, priority) ||
+                other.priority == priority) &&
+            const DeepCollectionEquality().equals(other._tags, _tags) &&
+            (identical(other.isRead, isRead) || other.isRead == isRead) &&
+            (identical(other.isStarred, isStarred) ||
+                other.isStarred == isStarred) &&
+            (identical(other.snoozedUntil, snoozedUntil) ||
+                other.snoozedUntil == snoozedUntil) &&
+            (identical(other.notes, notes) || other.notes == notes) &&
+            (identical(other.ingestedAt, ingestedAt) ||
+                other.ingestedAt == ingestedAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.completedAt, completedAt) ||
+                other.completedAt == completedAt));
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    runtimeType,
+    id,
+    providerId,
+    articleId,
+    feedId,
+    title,
+    author,
+    summary,
+    content,
+    url,
+    published,
+    updated,
+    status,
+    priority,
+    const DeepCollectionEquality().hash(_tags),
+    isRead,
+    isStarred,
+    snoozedUntil,
+    notes,
+    ingestedAt,
+    updatedAt,
+    completedAt,
+  ]);
+
+  /// Create a copy of WorkItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$WorkItemImplCopyWith<_$WorkItemImpl> get copyWith =>
+      __$$WorkItemImplCopyWithImpl<_$WorkItemImpl>(this, _$identity);
+}
+
+abstract class _WorkItem extends WorkItem {
+  const factory _WorkItem({
+    required final String id,
+    required final String providerId,
+    required final String articleId,
+    required final String feedId,
+    required final String title,
+    final String? author,
+    final String? summary,
+    final String? content,
+    final String? url,
+    final DateTime? published,
+    final DateTime? updated,
+    final TriageStatus status,
+    final Priority priority,
+    final List<String> tags,
+    final bool isRead,
+    final bool isStarred,
+    final DateTime? snoozedUntil,
+    final String? notes,
+    required final DateTime ingestedAt,
+    required final DateTime updatedAt,
+    final DateTime? completedAt,
+  }) = _$WorkItemImpl;
+  const _WorkItem._() : super._();
+
+  @override
+  String get id;
+  @override
+  String get providerId;
+  @override
+  String get articleId;
+  @override
+  String get feedId;
+  @override
+  String get title;
+  @override
+  String? get author;
+  @override
+  String? get summary;
+  @override
+  String? get content;
+  @override
+  String? get url;
+  @override
+  DateTime? get published;
+  @override
+  DateTime? get updated;
+  @override
+  TriageStatus get status;
+  @override
+  Priority get priority;
+  @override
+  List<String> get tags;
+  @override
+  bool get isRead;
+  @override
+  bool get isStarred;
+  @override
+  DateTime? get snoozedUntil;
+  @override
+  String? get notes;
+  @override
+  DateTime get ingestedAt;
+  @override
+  DateTime get updatedAt;
+  @override
+  DateTime? get completedAt;
+
+  /// Create a copy of WorkItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$WorkItemImplCopyWith<_$WorkItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/infrastructure/db/database.dart
+++ b/lib/infrastructure/db/database.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'tables.dart';
+
+part 'database.g.dart';
+
+/// Banco local do FeedFlow (fonte de verdade dos [WorkItem]s e da trilha de
+/// eventos/enriquecimentos). Suporte nativo (Android/iOS/desktop) apenas
+/// nesta fase — web/WASM fica para uma iteração futura (ver EVOLUTION-PLAN,
+/// Fase 1: "web via WASM/OPFS" listado como risco a validar cedo no CI).
+@DriftDatabase(tables: [WorkItems, WorkItemEvents, Enrichments])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
+
+  @override
+  int get schemaVersion => 1;
+
+  static QueryExecutor _openConnection() {
+    return LazyDatabase(() async {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File(p.join(dir.path, 'feedflow_workitems.sqlite'));
+      return NativeDatabase.createInBackground(file);
+    });
+  }
+}

--- a/lib/infrastructure/db/database.g.dart
+++ b/lib/infrastructure/db/database.g.dart
@@ -1,0 +1,2979 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class $WorkItemsTable extends WorkItems
+    with TableInfo<$WorkItemsTable, WorkItemRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WorkItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _providerIdMeta = const VerificationMeta(
+    'providerId',
+  );
+  @override
+  late final GeneratedColumn<String> providerId = GeneratedColumn<String>(
+    'provider_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _articleIdMeta = const VerificationMeta(
+    'articleId',
+  );
+  @override
+  late final GeneratedColumn<String> articleId = GeneratedColumn<String>(
+    'article_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _feedIdMeta = const VerificationMeta('feedId');
+  @override
+  late final GeneratedColumn<String> feedId = GeneratedColumn<String>(
+    'feed_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _authorMeta = const VerificationMeta('author');
+  @override
+  late final GeneratedColumn<String> author = GeneratedColumn<String>(
+    'author',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _summaryMeta = const VerificationMeta(
+    'summary',
+  );
+  @override
+  late final GeneratedColumn<String> summary = GeneratedColumn<String>(
+    'summary',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _contentMeta = const VerificationMeta(
+    'content',
+  );
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+    'content',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _urlMeta = const VerificationMeta('url');
+  @override
+  late final GeneratedColumn<String> url = GeneratedColumn<String>(
+    'url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _publishedMeta = const VerificationMeta(
+    'published',
+  );
+  @override
+  late final GeneratedColumn<DateTime> published = GeneratedColumn<DateTime>(
+    'published',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _updatedMeta = const VerificationMeta(
+    'updated',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updated = GeneratedColumn<DateTime>(
+    'updated',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _statusMeta = const VerificationMeta('status');
+  @override
+  late final GeneratedColumn<String> status = GeneratedColumn<String>(
+    'status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('novo'),
+  );
+  static const VerificationMeta _priorityMeta = const VerificationMeta(
+    'priority',
+  );
+  @override
+  late final GeneratedColumn<String> priority = GeneratedColumn<String>(
+    'priority',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('none'),
+  );
+  static const VerificationMeta _tagsJsonMeta = const VerificationMeta(
+    'tagsJson',
+  );
+  @override
+  late final GeneratedColumn<String> tagsJson = GeneratedColumn<String>(
+    'tags_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('[]'),
+  );
+  static const VerificationMeta _isReadMeta = const VerificationMeta('isRead');
+  @override
+  late final GeneratedColumn<bool> isRead = GeneratedColumn<bool>(
+    'is_read',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_read" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _isStarredMeta = const VerificationMeta(
+    'isStarred',
+  );
+  @override
+  late final GeneratedColumn<bool> isStarred = GeneratedColumn<bool>(
+    'is_starred',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_starred" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _snoozedUntilMeta = const VerificationMeta(
+    'snoozedUntil',
+  );
+  @override
+  late final GeneratedColumn<DateTime> snoozedUntil = GeneratedColumn<DateTime>(
+    'snoozed_until',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _ingestedAtMeta = const VerificationMeta(
+    'ingestedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> ingestedAt = GeneratedColumn<DateTime>(
+    'ingested_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _completedAtMeta = const VerificationMeta(
+    'completedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> completedAt = GeneratedColumn<DateTime>(
+    'completed_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    providerId,
+    articleId,
+    feedId,
+    title,
+    author,
+    summary,
+    content,
+    url,
+    published,
+    updated,
+    status,
+    priority,
+    tagsJson,
+    isRead,
+    isStarred,
+    snoozedUntil,
+    notes,
+    ingestedAt,
+    updatedAt,
+    completedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'work_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WorkItemRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('provider_id')) {
+      context.handle(
+        _providerIdMeta,
+        providerId.isAcceptableOrUnknown(data['provider_id']!, _providerIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_providerIdMeta);
+    }
+    if (data.containsKey('article_id')) {
+      context.handle(
+        _articleIdMeta,
+        articleId.isAcceptableOrUnknown(data['article_id']!, _articleIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_articleIdMeta);
+    }
+    if (data.containsKey('feed_id')) {
+      context.handle(
+        _feedIdMeta,
+        feedId.isAcceptableOrUnknown(data['feed_id']!, _feedIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_feedIdMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('author')) {
+      context.handle(
+        _authorMeta,
+        author.isAcceptableOrUnknown(data['author']!, _authorMeta),
+      );
+    }
+    if (data.containsKey('summary')) {
+      context.handle(
+        _summaryMeta,
+        summary.isAcceptableOrUnknown(data['summary']!, _summaryMeta),
+      );
+    }
+    if (data.containsKey('content')) {
+      context.handle(
+        _contentMeta,
+        content.isAcceptableOrUnknown(data['content']!, _contentMeta),
+      );
+    }
+    if (data.containsKey('url')) {
+      context.handle(
+        _urlMeta,
+        url.isAcceptableOrUnknown(data['url']!, _urlMeta),
+      );
+    }
+    if (data.containsKey('published')) {
+      context.handle(
+        _publishedMeta,
+        published.isAcceptableOrUnknown(data['published']!, _publishedMeta),
+      );
+    }
+    if (data.containsKey('updated')) {
+      context.handle(
+        _updatedMeta,
+        updated.isAcceptableOrUnknown(data['updated']!, _updatedMeta),
+      );
+    }
+    if (data.containsKey('status')) {
+      context.handle(
+        _statusMeta,
+        status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('priority')) {
+      context.handle(
+        _priorityMeta,
+        priority.isAcceptableOrUnknown(data['priority']!, _priorityMeta),
+      );
+    }
+    if (data.containsKey('tags_json')) {
+      context.handle(
+        _tagsJsonMeta,
+        tagsJson.isAcceptableOrUnknown(data['tags_json']!, _tagsJsonMeta),
+      );
+    }
+    if (data.containsKey('is_read')) {
+      context.handle(
+        _isReadMeta,
+        isRead.isAcceptableOrUnknown(data['is_read']!, _isReadMeta),
+      );
+    }
+    if (data.containsKey('is_starred')) {
+      context.handle(
+        _isStarredMeta,
+        isStarred.isAcceptableOrUnknown(data['is_starred']!, _isStarredMeta),
+      );
+    }
+    if (data.containsKey('snoozed_until')) {
+      context.handle(
+        _snoozedUntilMeta,
+        snoozedUntil.isAcceptableOrUnknown(
+          data['snoozed_until']!,
+          _snoozedUntilMeta,
+        ),
+      );
+    }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
+    if (data.containsKey('ingested_at')) {
+      context.handle(
+        _ingestedAtMeta,
+        ingestedAt.isAcceptableOrUnknown(data['ingested_at']!, _ingestedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_ingestedAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('completed_at')) {
+      context.handle(
+        _completedAtMeta,
+        completedAt.isAcceptableOrUnknown(
+          data['completed_at']!,
+          _completedAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  WorkItemRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WorkItemRow(
+      id:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}id'],
+          )!,
+      providerId:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}provider_id'],
+          )!,
+      articleId:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}article_id'],
+          )!,
+      feedId:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}feed_id'],
+          )!,
+      title:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}title'],
+          )!,
+      author: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}author'],
+      ),
+      summary: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}summary'],
+      ),
+      content: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}content'],
+      ),
+      url: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}url'],
+      ),
+      published: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}published'],
+      ),
+      updated: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated'],
+      ),
+      status:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}status'],
+          )!,
+      priority:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}priority'],
+          )!,
+      tagsJson:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}tags_json'],
+          )!,
+      isRead:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.bool,
+            data['${effectivePrefix}is_read'],
+          )!,
+      isStarred:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.bool,
+            data['${effectivePrefix}is_starred'],
+          )!,
+      snoozedUntil: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}snoozed_until'],
+      ),
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
+      ingestedAt:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.dateTime,
+            data['${effectivePrefix}ingested_at'],
+          )!,
+      updatedAt:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.dateTime,
+            data['${effectivePrefix}updated_at'],
+          )!,
+      completedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}completed_at'],
+      ),
+    );
+  }
+
+  @override
+  $WorkItemsTable createAlias(String alias) {
+    return $WorkItemsTable(attachedDatabase, alias);
+  }
+}
+
+class WorkItemRow extends DataClass implements Insertable<WorkItemRow> {
+  final String id;
+  final String providerId;
+  final String articleId;
+  final String feedId;
+  final String title;
+  final String? author;
+  final String? summary;
+  final String? content;
+  final String? url;
+  final DateTime? published;
+  final DateTime? updated;
+  final String status;
+  final String priority;
+
+  /// Lista de tags serializada como JSON (`["a","b"]`).
+  final String tagsJson;
+  final bool isRead;
+  final bool isStarred;
+  final DateTime? snoozedUntil;
+  final String? notes;
+  final DateTime ingestedAt;
+  final DateTime updatedAt;
+  final DateTime? completedAt;
+  const WorkItemRow({
+    required this.id,
+    required this.providerId,
+    required this.articleId,
+    required this.feedId,
+    required this.title,
+    this.author,
+    this.summary,
+    this.content,
+    this.url,
+    this.published,
+    this.updated,
+    required this.status,
+    required this.priority,
+    required this.tagsJson,
+    required this.isRead,
+    required this.isStarred,
+    this.snoozedUntil,
+    this.notes,
+    required this.ingestedAt,
+    required this.updatedAt,
+    this.completedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['provider_id'] = Variable<String>(providerId);
+    map['article_id'] = Variable<String>(articleId);
+    map['feed_id'] = Variable<String>(feedId);
+    map['title'] = Variable<String>(title);
+    if (!nullToAbsent || author != null) {
+      map['author'] = Variable<String>(author);
+    }
+    if (!nullToAbsent || summary != null) {
+      map['summary'] = Variable<String>(summary);
+    }
+    if (!nullToAbsent || content != null) {
+      map['content'] = Variable<String>(content);
+    }
+    if (!nullToAbsent || url != null) {
+      map['url'] = Variable<String>(url);
+    }
+    if (!nullToAbsent || published != null) {
+      map['published'] = Variable<DateTime>(published);
+    }
+    if (!nullToAbsent || updated != null) {
+      map['updated'] = Variable<DateTime>(updated);
+    }
+    map['status'] = Variable<String>(status);
+    map['priority'] = Variable<String>(priority);
+    map['tags_json'] = Variable<String>(tagsJson);
+    map['is_read'] = Variable<bool>(isRead);
+    map['is_starred'] = Variable<bool>(isStarred);
+    if (!nullToAbsent || snoozedUntil != null) {
+      map['snoozed_until'] = Variable<DateTime>(snoozedUntil);
+    }
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
+    }
+    map['ingested_at'] = Variable<DateTime>(ingestedAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || completedAt != null) {
+      map['completed_at'] = Variable<DateTime>(completedAt);
+    }
+    return map;
+  }
+
+  WorkItemsCompanion toCompanion(bool nullToAbsent) {
+    return WorkItemsCompanion(
+      id: Value(id),
+      providerId: Value(providerId),
+      articleId: Value(articleId),
+      feedId: Value(feedId),
+      title: Value(title),
+      author:
+          author == null && nullToAbsent ? const Value.absent() : Value(author),
+      summary:
+          summary == null && nullToAbsent
+              ? const Value.absent()
+              : Value(summary),
+      content:
+          content == null && nullToAbsent
+              ? const Value.absent()
+              : Value(content),
+      url: url == null && nullToAbsent ? const Value.absent() : Value(url),
+      published:
+          published == null && nullToAbsent
+              ? const Value.absent()
+              : Value(published),
+      updated:
+          updated == null && nullToAbsent
+              ? const Value.absent()
+              : Value(updated),
+      status: Value(status),
+      priority: Value(priority),
+      tagsJson: Value(tagsJson),
+      isRead: Value(isRead),
+      isStarred: Value(isStarred),
+      snoozedUntil:
+          snoozedUntil == null && nullToAbsent
+              ? const Value.absent()
+              : Value(snoozedUntil),
+      notes:
+          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
+      ingestedAt: Value(ingestedAt),
+      updatedAt: Value(updatedAt),
+      completedAt:
+          completedAt == null && nullToAbsent
+              ? const Value.absent()
+              : Value(completedAt),
+    );
+  }
+
+  factory WorkItemRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WorkItemRow(
+      id: serializer.fromJson<String>(json['id']),
+      providerId: serializer.fromJson<String>(json['providerId']),
+      articleId: serializer.fromJson<String>(json['articleId']),
+      feedId: serializer.fromJson<String>(json['feedId']),
+      title: serializer.fromJson<String>(json['title']),
+      author: serializer.fromJson<String?>(json['author']),
+      summary: serializer.fromJson<String?>(json['summary']),
+      content: serializer.fromJson<String?>(json['content']),
+      url: serializer.fromJson<String?>(json['url']),
+      published: serializer.fromJson<DateTime?>(json['published']),
+      updated: serializer.fromJson<DateTime?>(json['updated']),
+      status: serializer.fromJson<String>(json['status']),
+      priority: serializer.fromJson<String>(json['priority']),
+      tagsJson: serializer.fromJson<String>(json['tagsJson']),
+      isRead: serializer.fromJson<bool>(json['isRead']),
+      isStarred: serializer.fromJson<bool>(json['isStarred']),
+      snoozedUntil: serializer.fromJson<DateTime?>(json['snoozedUntil']),
+      notes: serializer.fromJson<String?>(json['notes']),
+      ingestedAt: serializer.fromJson<DateTime>(json['ingestedAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      completedAt: serializer.fromJson<DateTime?>(json['completedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'providerId': serializer.toJson<String>(providerId),
+      'articleId': serializer.toJson<String>(articleId),
+      'feedId': serializer.toJson<String>(feedId),
+      'title': serializer.toJson<String>(title),
+      'author': serializer.toJson<String?>(author),
+      'summary': serializer.toJson<String?>(summary),
+      'content': serializer.toJson<String?>(content),
+      'url': serializer.toJson<String?>(url),
+      'published': serializer.toJson<DateTime?>(published),
+      'updated': serializer.toJson<DateTime?>(updated),
+      'status': serializer.toJson<String>(status),
+      'priority': serializer.toJson<String>(priority),
+      'tagsJson': serializer.toJson<String>(tagsJson),
+      'isRead': serializer.toJson<bool>(isRead),
+      'isStarred': serializer.toJson<bool>(isStarred),
+      'snoozedUntil': serializer.toJson<DateTime?>(snoozedUntil),
+      'notes': serializer.toJson<String?>(notes),
+      'ingestedAt': serializer.toJson<DateTime>(ingestedAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'completedAt': serializer.toJson<DateTime?>(completedAt),
+    };
+  }
+
+  WorkItemRow copyWith({
+    String? id,
+    String? providerId,
+    String? articleId,
+    String? feedId,
+    String? title,
+    Value<String?> author = const Value.absent(),
+    Value<String?> summary = const Value.absent(),
+    Value<String?> content = const Value.absent(),
+    Value<String?> url = const Value.absent(),
+    Value<DateTime?> published = const Value.absent(),
+    Value<DateTime?> updated = const Value.absent(),
+    String? status,
+    String? priority,
+    String? tagsJson,
+    bool? isRead,
+    bool? isStarred,
+    Value<DateTime?> snoozedUntil = const Value.absent(),
+    Value<String?> notes = const Value.absent(),
+    DateTime? ingestedAt,
+    DateTime? updatedAt,
+    Value<DateTime?> completedAt = const Value.absent(),
+  }) => WorkItemRow(
+    id: id ?? this.id,
+    providerId: providerId ?? this.providerId,
+    articleId: articleId ?? this.articleId,
+    feedId: feedId ?? this.feedId,
+    title: title ?? this.title,
+    author: author.present ? author.value : this.author,
+    summary: summary.present ? summary.value : this.summary,
+    content: content.present ? content.value : this.content,
+    url: url.present ? url.value : this.url,
+    published: published.present ? published.value : this.published,
+    updated: updated.present ? updated.value : this.updated,
+    status: status ?? this.status,
+    priority: priority ?? this.priority,
+    tagsJson: tagsJson ?? this.tagsJson,
+    isRead: isRead ?? this.isRead,
+    isStarred: isStarred ?? this.isStarred,
+    snoozedUntil: snoozedUntil.present ? snoozedUntil.value : this.snoozedUntil,
+    notes: notes.present ? notes.value : this.notes,
+    ingestedAt: ingestedAt ?? this.ingestedAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    completedAt: completedAt.present ? completedAt.value : this.completedAt,
+  );
+  WorkItemRow copyWithCompanion(WorkItemsCompanion data) {
+    return WorkItemRow(
+      id: data.id.present ? data.id.value : this.id,
+      providerId:
+          data.providerId.present ? data.providerId.value : this.providerId,
+      articleId: data.articleId.present ? data.articleId.value : this.articleId,
+      feedId: data.feedId.present ? data.feedId.value : this.feedId,
+      title: data.title.present ? data.title.value : this.title,
+      author: data.author.present ? data.author.value : this.author,
+      summary: data.summary.present ? data.summary.value : this.summary,
+      content: data.content.present ? data.content.value : this.content,
+      url: data.url.present ? data.url.value : this.url,
+      published: data.published.present ? data.published.value : this.published,
+      updated: data.updated.present ? data.updated.value : this.updated,
+      status: data.status.present ? data.status.value : this.status,
+      priority: data.priority.present ? data.priority.value : this.priority,
+      tagsJson: data.tagsJson.present ? data.tagsJson.value : this.tagsJson,
+      isRead: data.isRead.present ? data.isRead.value : this.isRead,
+      isStarred: data.isStarred.present ? data.isStarred.value : this.isStarred,
+      snoozedUntil:
+          data.snoozedUntil.present
+              ? data.snoozedUntil.value
+              : this.snoozedUntil,
+      notes: data.notes.present ? data.notes.value : this.notes,
+      ingestedAt:
+          data.ingestedAt.present ? data.ingestedAt.value : this.ingestedAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      completedAt:
+          data.completedAt.present ? data.completedAt.value : this.completedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkItemRow(')
+          ..write('id: $id, ')
+          ..write('providerId: $providerId, ')
+          ..write('articleId: $articleId, ')
+          ..write('feedId: $feedId, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('summary: $summary, ')
+          ..write('content: $content, ')
+          ..write('url: $url, ')
+          ..write('published: $published, ')
+          ..write('updated: $updated, ')
+          ..write('status: $status, ')
+          ..write('priority: $priority, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('isRead: $isRead, ')
+          ..write('isStarred: $isStarred, ')
+          ..write('snoozedUntil: $snoozedUntil, ')
+          ..write('notes: $notes, ')
+          ..write('ingestedAt: $ingestedAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('completedAt: $completedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hashAll([
+    id,
+    providerId,
+    articleId,
+    feedId,
+    title,
+    author,
+    summary,
+    content,
+    url,
+    published,
+    updated,
+    status,
+    priority,
+    tagsJson,
+    isRead,
+    isStarred,
+    snoozedUntil,
+    notes,
+    ingestedAt,
+    updatedAt,
+    completedAt,
+  ]);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WorkItemRow &&
+          other.id == this.id &&
+          other.providerId == this.providerId &&
+          other.articleId == this.articleId &&
+          other.feedId == this.feedId &&
+          other.title == this.title &&
+          other.author == this.author &&
+          other.summary == this.summary &&
+          other.content == this.content &&
+          other.url == this.url &&
+          other.published == this.published &&
+          other.updated == this.updated &&
+          other.status == this.status &&
+          other.priority == this.priority &&
+          other.tagsJson == this.tagsJson &&
+          other.isRead == this.isRead &&
+          other.isStarred == this.isStarred &&
+          other.snoozedUntil == this.snoozedUntil &&
+          other.notes == this.notes &&
+          other.ingestedAt == this.ingestedAt &&
+          other.updatedAt == this.updatedAt &&
+          other.completedAt == this.completedAt);
+}
+
+class WorkItemsCompanion extends UpdateCompanion<WorkItemRow> {
+  final Value<String> id;
+  final Value<String> providerId;
+  final Value<String> articleId;
+  final Value<String> feedId;
+  final Value<String> title;
+  final Value<String?> author;
+  final Value<String?> summary;
+  final Value<String?> content;
+  final Value<String?> url;
+  final Value<DateTime?> published;
+  final Value<DateTime?> updated;
+  final Value<String> status;
+  final Value<String> priority;
+  final Value<String> tagsJson;
+  final Value<bool> isRead;
+  final Value<bool> isStarred;
+  final Value<DateTime?> snoozedUntil;
+  final Value<String?> notes;
+  final Value<DateTime> ingestedAt;
+  final Value<DateTime> updatedAt;
+  final Value<DateTime?> completedAt;
+  final Value<int> rowid;
+  const WorkItemsCompanion({
+    this.id = const Value.absent(),
+    this.providerId = const Value.absent(),
+    this.articleId = const Value.absent(),
+    this.feedId = const Value.absent(),
+    this.title = const Value.absent(),
+    this.author = const Value.absent(),
+    this.summary = const Value.absent(),
+    this.content = const Value.absent(),
+    this.url = const Value.absent(),
+    this.published = const Value.absent(),
+    this.updated = const Value.absent(),
+    this.status = const Value.absent(),
+    this.priority = const Value.absent(),
+    this.tagsJson = const Value.absent(),
+    this.isRead = const Value.absent(),
+    this.isStarred = const Value.absent(),
+    this.snoozedUntil = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.ingestedAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.completedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  WorkItemsCompanion.insert({
+    required String id,
+    required String providerId,
+    required String articleId,
+    required String feedId,
+    required String title,
+    this.author = const Value.absent(),
+    this.summary = const Value.absent(),
+    this.content = const Value.absent(),
+    this.url = const Value.absent(),
+    this.published = const Value.absent(),
+    this.updated = const Value.absent(),
+    this.status = const Value.absent(),
+    this.priority = const Value.absent(),
+    this.tagsJson = const Value.absent(),
+    this.isRead = const Value.absent(),
+    this.isStarred = const Value.absent(),
+    this.snoozedUntil = const Value.absent(),
+    this.notes = const Value.absent(),
+    required DateTime ingestedAt,
+    required DateTime updatedAt,
+    this.completedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       providerId = Value(providerId),
+       articleId = Value(articleId),
+       feedId = Value(feedId),
+       title = Value(title),
+       ingestedAt = Value(ingestedAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<WorkItemRow> custom({
+    Expression<String>? id,
+    Expression<String>? providerId,
+    Expression<String>? articleId,
+    Expression<String>? feedId,
+    Expression<String>? title,
+    Expression<String>? author,
+    Expression<String>? summary,
+    Expression<String>? content,
+    Expression<String>? url,
+    Expression<DateTime>? published,
+    Expression<DateTime>? updated,
+    Expression<String>? status,
+    Expression<String>? priority,
+    Expression<String>? tagsJson,
+    Expression<bool>? isRead,
+    Expression<bool>? isStarred,
+    Expression<DateTime>? snoozedUntil,
+    Expression<String>? notes,
+    Expression<DateTime>? ingestedAt,
+    Expression<DateTime>? updatedAt,
+    Expression<DateTime>? completedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (providerId != null) 'provider_id': providerId,
+      if (articleId != null) 'article_id': articleId,
+      if (feedId != null) 'feed_id': feedId,
+      if (title != null) 'title': title,
+      if (author != null) 'author': author,
+      if (summary != null) 'summary': summary,
+      if (content != null) 'content': content,
+      if (url != null) 'url': url,
+      if (published != null) 'published': published,
+      if (updated != null) 'updated': updated,
+      if (status != null) 'status': status,
+      if (priority != null) 'priority': priority,
+      if (tagsJson != null) 'tags_json': tagsJson,
+      if (isRead != null) 'is_read': isRead,
+      if (isStarred != null) 'is_starred': isStarred,
+      if (snoozedUntil != null) 'snoozed_until': snoozedUntil,
+      if (notes != null) 'notes': notes,
+      if (ingestedAt != null) 'ingested_at': ingestedAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (completedAt != null) 'completed_at': completedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  WorkItemsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? providerId,
+    Value<String>? articleId,
+    Value<String>? feedId,
+    Value<String>? title,
+    Value<String?>? author,
+    Value<String?>? summary,
+    Value<String?>? content,
+    Value<String?>? url,
+    Value<DateTime?>? published,
+    Value<DateTime?>? updated,
+    Value<String>? status,
+    Value<String>? priority,
+    Value<String>? tagsJson,
+    Value<bool>? isRead,
+    Value<bool>? isStarred,
+    Value<DateTime?>? snoozedUntil,
+    Value<String?>? notes,
+    Value<DateTime>? ingestedAt,
+    Value<DateTime>? updatedAt,
+    Value<DateTime?>? completedAt,
+    Value<int>? rowid,
+  }) {
+    return WorkItemsCompanion(
+      id: id ?? this.id,
+      providerId: providerId ?? this.providerId,
+      articleId: articleId ?? this.articleId,
+      feedId: feedId ?? this.feedId,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      summary: summary ?? this.summary,
+      content: content ?? this.content,
+      url: url ?? this.url,
+      published: published ?? this.published,
+      updated: updated ?? this.updated,
+      status: status ?? this.status,
+      priority: priority ?? this.priority,
+      tagsJson: tagsJson ?? this.tagsJson,
+      isRead: isRead ?? this.isRead,
+      isStarred: isStarred ?? this.isStarred,
+      snoozedUntil: snoozedUntil ?? this.snoozedUntil,
+      notes: notes ?? this.notes,
+      ingestedAt: ingestedAt ?? this.ingestedAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      completedAt: completedAt ?? this.completedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (providerId.present) {
+      map['provider_id'] = Variable<String>(providerId.value);
+    }
+    if (articleId.present) {
+      map['article_id'] = Variable<String>(articleId.value);
+    }
+    if (feedId.present) {
+      map['feed_id'] = Variable<String>(feedId.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (author.present) {
+      map['author'] = Variable<String>(author.value);
+    }
+    if (summary.present) {
+      map['summary'] = Variable<String>(summary.value);
+    }
+    if (content.present) {
+      map['content'] = Variable<String>(content.value);
+    }
+    if (url.present) {
+      map['url'] = Variable<String>(url.value);
+    }
+    if (published.present) {
+      map['published'] = Variable<DateTime>(published.value);
+    }
+    if (updated.present) {
+      map['updated'] = Variable<DateTime>(updated.value);
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(status.value);
+    }
+    if (priority.present) {
+      map['priority'] = Variable<String>(priority.value);
+    }
+    if (tagsJson.present) {
+      map['tags_json'] = Variable<String>(tagsJson.value);
+    }
+    if (isRead.present) {
+      map['is_read'] = Variable<bool>(isRead.value);
+    }
+    if (isStarred.present) {
+      map['is_starred'] = Variable<bool>(isStarred.value);
+    }
+    if (snoozedUntil.present) {
+      map['snoozed_until'] = Variable<DateTime>(snoozedUntil.value);
+    }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
+    if (ingestedAt.present) {
+      map['ingested_at'] = Variable<DateTime>(ingestedAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (completedAt.present) {
+      map['completed_at'] = Variable<DateTime>(completedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkItemsCompanion(')
+          ..write('id: $id, ')
+          ..write('providerId: $providerId, ')
+          ..write('articleId: $articleId, ')
+          ..write('feedId: $feedId, ')
+          ..write('title: $title, ')
+          ..write('author: $author, ')
+          ..write('summary: $summary, ')
+          ..write('content: $content, ')
+          ..write('url: $url, ')
+          ..write('published: $published, ')
+          ..write('updated: $updated, ')
+          ..write('status: $status, ')
+          ..write('priority: $priority, ')
+          ..write('tagsJson: $tagsJson, ')
+          ..write('isRead: $isRead, ')
+          ..write('isStarred: $isStarred, ')
+          ..write('snoozedUntil: $snoozedUntil, ')
+          ..write('notes: $notes, ')
+          ..write('ingestedAt: $ingestedAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('completedAt: $completedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $WorkItemEventsTable extends WorkItemEvents
+    with TableInfo<$WorkItemEventsTable, WorkItemEvent> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WorkItemEventsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _workItemIdMeta = const VerificationMeta(
+    'workItemId',
+  );
+  @override
+  late final GeneratedColumn<String> workItemId = GeneratedColumn<String>(
+    'work_item_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _actorMeta = const VerificationMeta('actor');
+  @override
+  late final GeneratedColumn<String> actor = GeneratedColumn<String>(
+    'actor',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _payloadJsonMeta = const VerificationMeta(
+    'payloadJson',
+  );
+  @override
+  late final GeneratedColumn<String> payloadJson = GeneratedColumn<String>(
+    'payload_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('{}'),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    workItemId,
+    timestamp,
+    type,
+    actor,
+    payloadJson,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'work_item_events';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WorkItemEvent> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('work_item_id')) {
+      context.handle(
+        _workItemIdMeta,
+        workItemId.isAcceptableOrUnknown(
+          data['work_item_id']!,
+          _workItemIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_workItemIdMeta);
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_typeMeta);
+    }
+    if (data.containsKey('actor')) {
+      context.handle(
+        _actorMeta,
+        actor.isAcceptableOrUnknown(data['actor']!, _actorMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_actorMeta);
+    }
+    if (data.containsKey('payload_json')) {
+      context.handle(
+        _payloadJsonMeta,
+        payloadJson.isAcceptableOrUnknown(
+          data['payload_json']!,
+          _payloadJsonMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  WorkItemEvent map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WorkItemEvent(
+      id:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.int,
+            data['${effectivePrefix}id'],
+          )!,
+      workItemId:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}work_item_id'],
+          )!,
+      timestamp:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.dateTime,
+            data['${effectivePrefix}timestamp'],
+          )!,
+      type:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}type'],
+          )!,
+      actor:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}actor'],
+          )!,
+      payloadJson:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}payload_json'],
+          )!,
+    );
+  }
+
+  @override
+  $WorkItemEventsTable createAlias(String alias) {
+    return $WorkItemEventsTable(attachedDatabase, alias);
+  }
+}
+
+class WorkItemEvent extends DataClass implements Insertable<WorkItemEvent> {
+  final int id;
+  final String workItemId;
+  final DateTime timestamp;
+
+  /// statusChanged | snoozed | snoozeExpired | actionExecuted | ruleMatched | ingested
+  final String type;
+
+  /// user | rule | sync
+  final String actor;
+  final String payloadJson;
+  const WorkItemEvent({
+    required this.id,
+    required this.workItemId,
+    required this.timestamp,
+    required this.type,
+    required this.actor,
+    required this.payloadJson,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['work_item_id'] = Variable<String>(workItemId);
+    map['timestamp'] = Variable<DateTime>(timestamp);
+    map['type'] = Variable<String>(type);
+    map['actor'] = Variable<String>(actor);
+    map['payload_json'] = Variable<String>(payloadJson);
+    return map;
+  }
+
+  WorkItemEventsCompanion toCompanion(bool nullToAbsent) {
+    return WorkItemEventsCompanion(
+      id: Value(id),
+      workItemId: Value(workItemId),
+      timestamp: Value(timestamp),
+      type: Value(type),
+      actor: Value(actor),
+      payloadJson: Value(payloadJson),
+    );
+  }
+
+  factory WorkItemEvent.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WorkItemEvent(
+      id: serializer.fromJson<int>(json['id']),
+      workItemId: serializer.fromJson<String>(json['workItemId']),
+      timestamp: serializer.fromJson<DateTime>(json['timestamp']),
+      type: serializer.fromJson<String>(json['type']),
+      actor: serializer.fromJson<String>(json['actor']),
+      payloadJson: serializer.fromJson<String>(json['payloadJson']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'workItemId': serializer.toJson<String>(workItemId),
+      'timestamp': serializer.toJson<DateTime>(timestamp),
+      'type': serializer.toJson<String>(type),
+      'actor': serializer.toJson<String>(actor),
+      'payloadJson': serializer.toJson<String>(payloadJson),
+    };
+  }
+
+  WorkItemEvent copyWith({
+    int? id,
+    String? workItemId,
+    DateTime? timestamp,
+    String? type,
+    String? actor,
+    String? payloadJson,
+  }) => WorkItemEvent(
+    id: id ?? this.id,
+    workItemId: workItemId ?? this.workItemId,
+    timestamp: timestamp ?? this.timestamp,
+    type: type ?? this.type,
+    actor: actor ?? this.actor,
+    payloadJson: payloadJson ?? this.payloadJson,
+  );
+  WorkItemEvent copyWithCompanion(WorkItemEventsCompanion data) {
+    return WorkItemEvent(
+      id: data.id.present ? data.id.value : this.id,
+      workItemId:
+          data.workItemId.present ? data.workItemId.value : this.workItemId,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      type: data.type.present ? data.type.value : this.type,
+      actor: data.actor.present ? data.actor.value : this.actor,
+      payloadJson:
+          data.payloadJson.present ? data.payloadJson.value : this.payloadJson,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkItemEvent(')
+          ..write('id: $id, ')
+          ..write('workItemId: $workItemId, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('type: $type, ')
+          ..write('actor: $actor, ')
+          ..write('payloadJson: $payloadJson')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, workItemId, timestamp, type, actor, payloadJson);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WorkItemEvent &&
+          other.id == this.id &&
+          other.workItemId == this.workItemId &&
+          other.timestamp == this.timestamp &&
+          other.type == this.type &&
+          other.actor == this.actor &&
+          other.payloadJson == this.payloadJson);
+}
+
+class WorkItemEventsCompanion extends UpdateCompanion<WorkItemEvent> {
+  final Value<int> id;
+  final Value<String> workItemId;
+  final Value<DateTime> timestamp;
+  final Value<String> type;
+  final Value<String> actor;
+  final Value<String> payloadJson;
+  const WorkItemEventsCompanion({
+    this.id = const Value.absent(),
+    this.workItemId = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.type = const Value.absent(),
+    this.actor = const Value.absent(),
+    this.payloadJson = const Value.absent(),
+  });
+  WorkItemEventsCompanion.insert({
+    this.id = const Value.absent(),
+    required String workItemId,
+    required DateTime timestamp,
+    required String type,
+    required String actor,
+    this.payloadJson = const Value.absent(),
+  }) : workItemId = Value(workItemId),
+       timestamp = Value(timestamp),
+       type = Value(type),
+       actor = Value(actor);
+  static Insertable<WorkItemEvent> custom({
+    Expression<int>? id,
+    Expression<String>? workItemId,
+    Expression<DateTime>? timestamp,
+    Expression<String>? type,
+    Expression<String>? actor,
+    Expression<String>? payloadJson,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (workItemId != null) 'work_item_id': workItemId,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (type != null) 'type': type,
+      if (actor != null) 'actor': actor,
+      if (payloadJson != null) 'payload_json': payloadJson,
+    });
+  }
+
+  WorkItemEventsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? workItemId,
+    Value<DateTime>? timestamp,
+    Value<String>? type,
+    Value<String>? actor,
+    Value<String>? payloadJson,
+  }) {
+    return WorkItemEventsCompanion(
+      id: id ?? this.id,
+      workItemId: workItemId ?? this.workItemId,
+      timestamp: timestamp ?? this.timestamp,
+      type: type ?? this.type,
+      actor: actor ?? this.actor,
+      payloadJson: payloadJson ?? this.payloadJson,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (workItemId.present) {
+      map['work_item_id'] = Variable<String>(workItemId.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<DateTime>(timestamp.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (actor.present) {
+      map['actor'] = Variable<String>(actor.value);
+    }
+    if (payloadJson.present) {
+      map['payload_json'] = Variable<String>(payloadJson.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkItemEventsCompanion(')
+          ..write('id: $id, ')
+          ..write('workItemId: $workItemId, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('type: $type, ')
+          ..write('actor: $actor, ')
+          ..write('payloadJson: $payloadJson')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $EnrichmentsTable extends Enrichments
+    with TableInfo<$EnrichmentsTable, Enrichment> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $EnrichmentsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _workItemIdMeta = const VerificationMeta(
+    'workItemId',
+  );
+  @override
+  late final GeneratedColumn<String> workItemId = GeneratedColumn<String>(
+    'work_item_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _contentMeta = const VerificationMeta(
+    'content',
+  );
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+    'content',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _modelMeta = const VerificationMeta('model');
+  @override
+  late final GeneratedColumn<String> model = GeneratedColumn<String>(
+    'model',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    workItemId,
+    type,
+    content,
+    model,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'enrichments';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Enrichment> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('work_item_id')) {
+      context.handle(
+        _workItemIdMeta,
+        workItemId.isAcceptableOrUnknown(
+          data['work_item_id']!,
+          _workItemIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_workItemIdMeta);
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_typeMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(
+        _contentMeta,
+        content.isAcceptableOrUnknown(data['content']!, _contentMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('model')) {
+      context.handle(
+        _modelMeta,
+        model.isAcceptableOrUnknown(data['model']!, _modelMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Enrichment map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Enrichment(
+      id:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.int,
+            data['${effectivePrefix}id'],
+          )!,
+      workItemId:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}work_item_id'],
+          )!,
+      type:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}type'],
+          )!,
+      content:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.string,
+            data['${effectivePrefix}content'],
+          )!,
+      model: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}model'],
+      ),
+      createdAt:
+          attachedDatabase.typeMapping.read(
+            DriftSqlType.dateTime,
+            data['${effectivePrefix}created_at'],
+          )!,
+    );
+  }
+
+  @override
+  $EnrichmentsTable createAlias(String alias) {
+    return $EnrichmentsTable(attachedDatabase, alias);
+  }
+}
+
+class Enrichment extends DataClass implements Insertable<Enrichment> {
+  final int id;
+  final String workItemId;
+
+  /// summary | translation | classification | entities | suggestion
+  final String type;
+  final String content;
+  final String? model;
+  final DateTime createdAt;
+  const Enrichment({
+    required this.id,
+    required this.workItemId,
+    required this.type,
+    required this.content,
+    this.model,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['work_item_id'] = Variable<String>(workItemId);
+    map['type'] = Variable<String>(type);
+    map['content'] = Variable<String>(content);
+    if (!nullToAbsent || model != null) {
+      map['model'] = Variable<String>(model);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  EnrichmentsCompanion toCompanion(bool nullToAbsent) {
+    return EnrichmentsCompanion(
+      id: Value(id),
+      workItemId: Value(workItemId),
+      type: Value(type),
+      content: Value(content),
+      model:
+          model == null && nullToAbsent ? const Value.absent() : Value(model),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory Enrichment.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Enrichment(
+      id: serializer.fromJson<int>(json['id']),
+      workItemId: serializer.fromJson<String>(json['workItemId']),
+      type: serializer.fromJson<String>(json['type']),
+      content: serializer.fromJson<String>(json['content']),
+      model: serializer.fromJson<String?>(json['model']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'workItemId': serializer.toJson<String>(workItemId),
+      'type': serializer.toJson<String>(type),
+      'content': serializer.toJson<String>(content),
+      'model': serializer.toJson<String?>(model),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  Enrichment copyWith({
+    int? id,
+    String? workItemId,
+    String? type,
+    String? content,
+    Value<String?> model = const Value.absent(),
+    DateTime? createdAt,
+  }) => Enrichment(
+    id: id ?? this.id,
+    workItemId: workItemId ?? this.workItemId,
+    type: type ?? this.type,
+    content: content ?? this.content,
+    model: model.present ? model.value : this.model,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  Enrichment copyWithCompanion(EnrichmentsCompanion data) {
+    return Enrichment(
+      id: data.id.present ? data.id.value : this.id,
+      workItemId:
+          data.workItemId.present ? data.workItemId.value : this.workItemId,
+      type: data.type.present ? data.type.value : this.type,
+      content: data.content.present ? data.content.value : this.content,
+      model: data.model.present ? data.model.value : this.model,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Enrichment(')
+          ..write('id: $id, ')
+          ..write('workItemId: $workItemId, ')
+          ..write('type: $type, ')
+          ..write('content: $content, ')
+          ..write('model: $model, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, workItemId, type, content, model, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Enrichment &&
+          other.id == this.id &&
+          other.workItemId == this.workItemId &&
+          other.type == this.type &&
+          other.content == this.content &&
+          other.model == this.model &&
+          other.createdAt == this.createdAt);
+}
+
+class EnrichmentsCompanion extends UpdateCompanion<Enrichment> {
+  final Value<int> id;
+  final Value<String> workItemId;
+  final Value<String> type;
+  final Value<String> content;
+  final Value<String?> model;
+  final Value<DateTime> createdAt;
+  const EnrichmentsCompanion({
+    this.id = const Value.absent(),
+    this.workItemId = const Value.absent(),
+    this.type = const Value.absent(),
+    this.content = const Value.absent(),
+    this.model = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  EnrichmentsCompanion.insert({
+    this.id = const Value.absent(),
+    required String workItemId,
+    required String type,
+    required String content,
+    this.model = const Value.absent(),
+    required DateTime createdAt,
+  }) : workItemId = Value(workItemId),
+       type = Value(type),
+       content = Value(content),
+       createdAt = Value(createdAt);
+  static Insertable<Enrichment> custom({
+    Expression<int>? id,
+    Expression<String>? workItemId,
+    Expression<String>? type,
+    Expression<String>? content,
+    Expression<String>? model,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (workItemId != null) 'work_item_id': workItemId,
+      if (type != null) 'type': type,
+      if (content != null) 'content': content,
+      if (model != null) 'model': model,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  EnrichmentsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? workItemId,
+    Value<String>? type,
+    Value<String>? content,
+    Value<String?>? model,
+    Value<DateTime>? createdAt,
+  }) {
+    return EnrichmentsCompanion(
+      id: id ?? this.id,
+      workItemId: workItemId ?? this.workItemId,
+      type: type ?? this.type,
+      content: content ?? this.content,
+      model: model ?? this.model,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (workItemId.present) {
+      map['work_item_id'] = Variable<String>(workItemId.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (content.present) {
+      map['content'] = Variable<String>(content.value);
+    }
+    if (model.present) {
+      map['model'] = Variable<String>(model.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('EnrichmentsCompanion(')
+          ..write('id: $id, ')
+          ..write('workItemId: $workItemId, ')
+          ..write('type: $type, ')
+          ..write('content: $content, ')
+          ..write('model: $model, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
+  $AppDatabaseManager get managers => $AppDatabaseManager(this);
+  late final $WorkItemsTable workItems = $WorkItemsTable(this);
+  late final $WorkItemEventsTable workItemEvents = $WorkItemEventsTable(this);
+  late final $EnrichmentsTable enrichments = $EnrichmentsTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    workItems,
+    workItemEvents,
+    enrichments,
+  ];
+}
+
+typedef $$WorkItemsTableCreateCompanionBuilder =
+    WorkItemsCompanion Function({
+      required String id,
+      required String providerId,
+      required String articleId,
+      required String feedId,
+      required String title,
+      Value<String?> author,
+      Value<String?> summary,
+      Value<String?> content,
+      Value<String?> url,
+      Value<DateTime?> published,
+      Value<DateTime?> updated,
+      Value<String> status,
+      Value<String> priority,
+      Value<String> tagsJson,
+      Value<bool> isRead,
+      Value<bool> isStarred,
+      Value<DateTime?> snoozedUntil,
+      Value<String?> notes,
+      required DateTime ingestedAt,
+      required DateTime updatedAt,
+      Value<DateTime?> completedAt,
+      Value<int> rowid,
+    });
+typedef $$WorkItemsTableUpdateCompanionBuilder =
+    WorkItemsCompanion Function({
+      Value<String> id,
+      Value<String> providerId,
+      Value<String> articleId,
+      Value<String> feedId,
+      Value<String> title,
+      Value<String?> author,
+      Value<String?> summary,
+      Value<String?> content,
+      Value<String?> url,
+      Value<DateTime?> published,
+      Value<DateTime?> updated,
+      Value<String> status,
+      Value<String> priority,
+      Value<String> tagsJson,
+      Value<bool> isRead,
+      Value<bool> isStarred,
+      Value<DateTime?> snoozedUntil,
+      Value<String?> notes,
+      Value<DateTime> ingestedAt,
+      Value<DateTime> updatedAt,
+      Value<DateTime?> completedAt,
+      Value<int> rowid,
+    });
+
+class $$WorkItemsTableFilterComposer
+    extends Composer<_$AppDatabase, $WorkItemsTable> {
+  $$WorkItemsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get articleId => $composableBuilder(
+    column: $table.articleId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get feedId => $composableBuilder(
+    column: $table.feedId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get published => $composableBuilder(
+    column: $table.published,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updated => $composableBuilder(
+    column: $table.updated,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get priority => $composableBuilder(
+    column: $table.priority,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get tagsJson => $composableBuilder(
+    column: $table.tagsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isRead => $composableBuilder(
+    column: $table.isRead,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isStarred => $composableBuilder(
+    column: $table.isStarred,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get ingestedAt => $composableBuilder(
+    column: $table.ingestedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WorkItemsTableOrderingComposer
+    extends Composer<_$AppDatabase, $WorkItemsTable> {
+  $$WorkItemsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get articleId => $composableBuilder(
+    column: $table.articleId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get feedId => $composableBuilder(
+    column: $table.feedId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get author => $composableBuilder(
+    column: $table.author,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get summary => $composableBuilder(
+    column: $table.summary,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get url => $composableBuilder(
+    column: $table.url,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get published => $composableBuilder(
+    column: $table.published,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updated => $composableBuilder(
+    column: $table.updated,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get priority => $composableBuilder(
+    column: $table.priority,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get tagsJson => $composableBuilder(
+    column: $table.tagsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isRead => $composableBuilder(
+    column: $table.isRead,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isStarred => $composableBuilder(
+    column: $table.isStarred,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get ingestedAt => $composableBuilder(
+    column: $table.ingestedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WorkItemsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WorkItemsTable> {
+  $$WorkItemsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get providerId => $composableBuilder(
+    column: $table.providerId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get articleId =>
+      $composableBuilder(column: $table.articleId, builder: (column) => column);
+
+  GeneratedColumn<String> get feedId =>
+      $composableBuilder(column: $table.feedId, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get author =>
+      $composableBuilder(column: $table.author, builder: (column) => column);
+
+  GeneratedColumn<String> get summary =>
+      $composableBuilder(column: $table.summary, builder: (column) => column);
+
+  GeneratedColumn<String> get content =>
+      $composableBuilder(column: $table.content, builder: (column) => column);
+
+  GeneratedColumn<String> get url =>
+      $composableBuilder(column: $table.url, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get published =>
+      $composableBuilder(column: $table.published, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updated =>
+      $composableBuilder(column: $table.updated, builder: (column) => column);
+
+  GeneratedColumn<String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<String> get priority =>
+      $composableBuilder(column: $table.priority, builder: (column) => column);
+
+  GeneratedColumn<String> get tagsJson =>
+      $composableBuilder(column: $table.tagsJson, builder: (column) => column);
+
+  GeneratedColumn<bool> get isRead =>
+      $composableBuilder(column: $table.isRead, builder: (column) => column);
+
+  GeneratedColumn<bool> get isStarred =>
+      $composableBuilder(column: $table.isStarred, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get snoozedUntil => $composableBuilder(
+    column: $table.snoozedUntil,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get ingestedAt => $composableBuilder(
+    column: $table.ingestedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => column,
+  );
+}
+
+class $$WorkItemsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WorkItemsTable,
+          WorkItemRow,
+          $$WorkItemsTableFilterComposer,
+          $$WorkItemsTableOrderingComposer,
+          $$WorkItemsTableAnnotationComposer,
+          $$WorkItemsTableCreateCompanionBuilder,
+          $$WorkItemsTableUpdateCompanionBuilder,
+          (
+            WorkItemRow,
+            BaseReferences<_$AppDatabase, $WorkItemsTable, WorkItemRow>,
+          ),
+          WorkItemRow,
+          PrefetchHooks Function()
+        > {
+  $$WorkItemsTableTableManager(_$AppDatabase db, $WorkItemsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer:
+              () => $$WorkItemsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer:
+              () => $$WorkItemsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer:
+              () => $$WorkItemsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> providerId = const Value.absent(),
+                Value<String> articleId = const Value.absent(),
+                Value<String> feedId = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String?> author = const Value.absent(),
+                Value<String?> summary = const Value.absent(),
+                Value<String?> content = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+                Value<DateTime?> published = const Value.absent(),
+                Value<DateTime?> updated = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String> priority = const Value.absent(),
+                Value<String> tagsJson = const Value.absent(),
+                Value<bool> isRead = const Value.absent(),
+                Value<bool> isStarred = const Value.absent(),
+                Value<DateTime?> snoozedUntil = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<DateTime> ingestedAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> completedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WorkItemsCompanion(
+                id: id,
+                providerId: providerId,
+                articleId: articleId,
+                feedId: feedId,
+                title: title,
+                author: author,
+                summary: summary,
+                content: content,
+                url: url,
+                published: published,
+                updated: updated,
+                status: status,
+                priority: priority,
+                tagsJson: tagsJson,
+                isRead: isRead,
+                isStarred: isStarred,
+                snoozedUntil: snoozedUntil,
+                notes: notes,
+                ingestedAt: ingestedAt,
+                updatedAt: updatedAt,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String providerId,
+                required String articleId,
+                required String feedId,
+                required String title,
+                Value<String?> author = const Value.absent(),
+                Value<String?> summary = const Value.absent(),
+                Value<String?> content = const Value.absent(),
+                Value<String?> url = const Value.absent(),
+                Value<DateTime?> published = const Value.absent(),
+                Value<DateTime?> updated = const Value.absent(),
+                Value<String> status = const Value.absent(),
+                Value<String> priority = const Value.absent(),
+                Value<String> tagsJson = const Value.absent(),
+                Value<bool> isRead = const Value.absent(),
+                Value<bool> isStarred = const Value.absent(),
+                Value<DateTime?> snoozedUntil = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                required DateTime ingestedAt,
+                required DateTime updatedAt,
+                Value<DateTime?> completedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WorkItemsCompanion.insert(
+                id: id,
+                providerId: providerId,
+                articleId: articleId,
+                feedId: feedId,
+                title: title,
+                author: author,
+                summary: summary,
+                content: content,
+                url: url,
+                published: published,
+                updated: updated,
+                status: status,
+                priority: priority,
+                tagsJson: tagsJson,
+                isRead: isRead,
+                isStarred: isStarred,
+                snoozedUntil: snoozedUntil,
+                notes: notes,
+                ingestedAt: ingestedAt,
+                updatedAt: updatedAt,
+                completedAt: completedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper:
+              (p0) =>
+                  p0
+                      .map(
+                        (e) => (
+                          e.readTable(table),
+                          BaseReferences(db, table, e),
+                        ),
+                      )
+                      .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WorkItemsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WorkItemsTable,
+      WorkItemRow,
+      $$WorkItemsTableFilterComposer,
+      $$WorkItemsTableOrderingComposer,
+      $$WorkItemsTableAnnotationComposer,
+      $$WorkItemsTableCreateCompanionBuilder,
+      $$WorkItemsTableUpdateCompanionBuilder,
+      (
+        WorkItemRow,
+        BaseReferences<_$AppDatabase, $WorkItemsTable, WorkItemRow>,
+      ),
+      WorkItemRow,
+      PrefetchHooks Function()
+    >;
+typedef $$WorkItemEventsTableCreateCompanionBuilder =
+    WorkItemEventsCompanion Function({
+      Value<int> id,
+      required String workItemId,
+      required DateTime timestamp,
+      required String type,
+      required String actor,
+      Value<String> payloadJson,
+    });
+typedef $$WorkItemEventsTableUpdateCompanionBuilder =
+    WorkItemEventsCompanion Function({
+      Value<int> id,
+      Value<String> workItemId,
+      Value<DateTime> timestamp,
+      Value<String> type,
+      Value<String> actor,
+      Value<String> payloadJson,
+    });
+
+class $$WorkItemEventsTableFilterComposer
+    extends Composer<_$AppDatabase, $WorkItemEventsTable> {
+  $$WorkItemEventsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get actor => $composableBuilder(
+    column: $table.actor,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WorkItemEventsTableOrderingComposer
+    extends Composer<_$AppDatabase, $WorkItemEventsTable> {
+  $$WorkItemEventsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get actor => $composableBuilder(
+    column: $table.actor,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WorkItemEventsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WorkItemEventsTable> {
+  $$WorkItemEventsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<String> get actor =>
+      $composableBuilder(column: $table.actor, builder: (column) => column);
+
+  GeneratedColumn<String> get payloadJson => $composableBuilder(
+    column: $table.payloadJson,
+    builder: (column) => column,
+  );
+}
+
+class $$WorkItemEventsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WorkItemEventsTable,
+          WorkItemEvent,
+          $$WorkItemEventsTableFilterComposer,
+          $$WorkItemEventsTableOrderingComposer,
+          $$WorkItemEventsTableAnnotationComposer,
+          $$WorkItemEventsTableCreateCompanionBuilder,
+          $$WorkItemEventsTableUpdateCompanionBuilder,
+          (
+            WorkItemEvent,
+            BaseReferences<_$AppDatabase, $WorkItemEventsTable, WorkItemEvent>,
+          ),
+          WorkItemEvent,
+          PrefetchHooks Function()
+        > {
+  $$WorkItemEventsTableTableManager(
+    _$AppDatabase db,
+    $WorkItemEventsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer:
+              () => $$WorkItemEventsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer:
+              () =>
+                  $$WorkItemEventsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer:
+              () => $$WorkItemEventsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> workItemId = const Value.absent(),
+                Value<DateTime> timestamp = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<String> actor = const Value.absent(),
+                Value<String> payloadJson = const Value.absent(),
+              }) => WorkItemEventsCompanion(
+                id: id,
+                workItemId: workItemId,
+                timestamp: timestamp,
+                type: type,
+                actor: actor,
+                payloadJson: payloadJson,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String workItemId,
+                required DateTime timestamp,
+                required String type,
+                required String actor,
+                Value<String> payloadJson = const Value.absent(),
+              }) => WorkItemEventsCompanion.insert(
+                id: id,
+                workItemId: workItemId,
+                timestamp: timestamp,
+                type: type,
+                actor: actor,
+                payloadJson: payloadJson,
+              ),
+          withReferenceMapper:
+              (p0) =>
+                  p0
+                      .map(
+                        (e) => (
+                          e.readTable(table),
+                          BaseReferences(db, table, e),
+                        ),
+                      )
+                      .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WorkItemEventsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WorkItemEventsTable,
+      WorkItemEvent,
+      $$WorkItemEventsTableFilterComposer,
+      $$WorkItemEventsTableOrderingComposer,
+      $$WorkItemEventsTableAnnotationComposer,
+      $$WorkItemEventsTableCreateCompanionBuilder,
+      $$WorkItemEventsTableUpdateCompanionBuilder,
+      (
+        WorkItemEvent,
+        BaseReferences<_$AppDatabase, $WorkItemEventsTable, WorkItemEvent>,
+      ),
+      WorkItemEvent,
+      PrefetchHooks Function()
+    >;
+typedef $$EnrichmentsTableCreateCompanionBuilder =
+    EnrichmentsCompanion Function({
+      Value<int> id,
+      required String workItemId,
+      required String type,
+      required String content,
+      Value<String?> model,
+      required DateTime createdAt,
+    });
+typedef $$EnrichmentsTableUpdateCompanionBuilder =
+    EnrichmentsCompanion Function({
+      Value<int> id,
+      Value<String> workItemId,
+      Value<String> type,
+      Value<String> content,
+      Value<String?> model,
+      Value<DateTime> createdAt,
+    });
+
+class $$EnrichmentsTableFilterComposer
+    extends Composer<_$AppDatabase, $EnrichmentsTable> {
+  $$EnrichmentsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get model => $composableBuilder(
+    column: $table.model,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$EnrichmentsTableOrderingComposer
+    extends Composer<_$AppDatabase, $EnrichmentsTable> {
+  $$EnrichmentsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get model => $composableBuilder(
+    column: $table.model,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$EnrichmentsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $EnrichmentsTable> {
+  $$EnrichmentsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get workItemId => $composableBuilder(
+    column: $table.workItemId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<String> get content =>
+      $composableBuilder(column: $table.content, builder: (column) => column);
+
+  GeneratedColumn<String> get model =>
+      $composableBuilder(column: $table.model, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$EnrichmentsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $EnrichmentsTable,
+          Enrichment,
+          $$EnrichmentsTableFilterComposer,
+          $$EnrichmentsTableOrderingComposer,
+          $$EnrichmentsTableAnnotationComposer,
+          $$EnrichmentsTableCreateCompanionBuilder,
+          $$EnrichmentsTableUpdateCompanionBuilder,
+          (
+            Enrichment,
+            BaseReferences<_$AppDatabase, $EnrichmentsTable, Enrichment>,
+          ),
+          Enrichment,
+          PrefetchHooks Function()
+        > {
+  $$EnrichmentsTableTableManager(_$AppDatabase db, $EnrichmentsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer:
+              () => $$EnrichmentsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer:
+              () => $$EnrichmentsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer:
+              () =>
+                  $$EnrichmentsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> workItemId = const Value.absent(),
+                Value<String> type = const Value.absent(),
+                Value<String> content = const Value.absent(),
+                Value<String?> model = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => EnrichmentsCompanion(
+                id: id,
+                workItemId: workItemId,
+                type: type,
+                content: content,
+                model: model,
+                createdAt: createdAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String workItemId,
+                required String type,
+                required String content,
+                Value<String?> model = const Value.absent(),
+                required DateTime createdAt,
+              }) => EnrichmentsCompanion.insert(
+                id: id,
+                workItemId: workItemId,
+                type: type,
+                content: content,
+                model: model,
+                createdAt: createdAt,
+              ),
+          withReferenceMapper:
+              (p0) =>
+                  p0
+                      .map(
+                        (e) => (
+                          e.readTable(table),
+                          BaseReferences(db, table, e),
+                        ),
+                      )
+                      .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$EnrichmentsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $EnrichmentsTable,
+      Enrichment,
+      $$EnrichmentsTableFilterComposer,
+      $$EnrichmentsTableOrderingComposer,
+      $$EnrichmentsTableAnnotationComposer,
+      $$EnrichmentsTableCreateCompanionBuilder,
+      $$EnrichmentsTableUpdateCompanionBuilder,
+      (
+        Enrichment,
+        BaseReferences<_$AppDatabase, $EnrichmentsTable, Enrichment>,
+      ),
+      Enrichment,
+      PrefetchHooks Function()
+    >;
+
+class $AppDatabaseManager {
+  final _$AppDatabase _db;
+  $AppDatabaseManager(this._db);
+  $$WorkItemsTableTableManager get workItems =>
+      $$WorkItemsTableTableManager(_db, _db.workItems);
+  $$WorkItemEventsTableTableManager get workItemEvents =>
+      $$WorkItemEventsTableTableManager(_db, _db.workItemEvents);
+  $$EnrichmentsTableTableManager get enrichments =>
+      $$EnrichmentsTableTableManager(_db, _db.enrichments);
+}

--- a/lib/infrastructure/db/database_provider.dart
+++ b/lib/infrastructure/db/database_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+
+import '../../domain/repositories/work_item_repository.dart';
+import '../repositories/work_item_repository_drift.dart';
+import 'database.dart';
+
+/// Acesso lazy ao banco local / [WorkItemRepository]. Sem web/WASM nesta
+/// fase (ver `AppDatabase`) — em `kIsWeb`, `repository` é `null` e chamadas
+/// de shadow-write viram no-op, sem quebrar a build web.
+class DatabaseProvider {
+  DatabaseProvider._();
+
+  static AppDatabase? _database;
+  static WorkItemRepository? _repository;
+
+  static WorkItemRepository? get repository {
+    if (kIsWeb) return null;
+    _database ??= AppDatabase();
+    return _repository ??= WorkItemRepositoryDrift(_database!);
+  }
+}

--- a/lib/infrastructure/db/tables.dart
+++ b/lib/infrastructure/db/tables.dart
@@ -1,0 +1,63 @@
+import 'package:drift/drift.dart';
+
+/// Um `WorkItem` de domínio por linha. `id` é `{providerId}:{articleId}`
+/// (ver `workItemIdFor` em `lib/domain/work_item.dart`).
+///
+/// `@DataClassName('WorkItemRow')` evita colisão com a classe de domínio
+/// `WorkItem` (Freezed) — o drift nomearia a row class `WorkItem` por
+/// padrão (singular de `WorkItems`).
+@DataClassName('WorkItemRow')
+class WorkItems extends Table {
+  TextColumn get id => text()();
+  TextColumn get providerId => text()();
+  TextColumn get articleId => text()();
+  TextColumn get feedId => text()();
+  TextColumn get title => text()();
+  TextColumn get author => text().nullable()();
+  TextColumn get summary => text().nullable()();
+  TextColumn get content => text().nullable()();
+  TextColumn get url => text().nullable()();
+  DateTimeColumn get published => dateTime().nullable()();
+  DateTimeColumn get updated => dateTime().nullable()();
+  TextColumn get status => text().withDefault(const Constant('novo'))();
+  TextColumn get priority => text().withDefault(const Constant('none'))();
+  /// Lista de tags serializada como JSON (`["a","b"]`).
+  TextColumn get tagsJson => text().withDefault(const Constant('[]'))();
+  BoolColumn get isRead => boolean().withDefault(const Constant(false))();
+  BoolColumn get isStarred => boolean().withDefault(const Constant(false))();
+  DateTimeColumn get snoozedUntil => dateTime().nullable()();
+  TextColumn get notes => text().nullable()();
+  DateTimeColumn get ingestedAt => dateTime()();
+  DateTimeColumn get updatedAt => dateTime()();
+  DateTimeColumn get completedAt => dateTime().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Trilha de auditoria de mudanças de um [WorkItem] — quem/o que moveu o
+/// item e quando. Base para "desfazer últimas N horas de uma regra" em
+/// fases futuras (motor de regras).
+class WorkItemEvents extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get workItemId => text()();
+  DateTimeColumn get timestamp => dateTime()();
+  /// statusChanged | snoozed | snoozeExpired | actionExecuted | ruleMatched | ingested
+  TextColumn get type => text()();
+  /// user | rule | sync
+  TextColumn get actor => text()();
+  TextColumn get payloadJson => text().withDefault(const Constant('{}'))();
+}
+
+/// Enriquecimentos de IA (resumo, tradução, classificação, ...) associados a
+/// um [WorkItem]. Schema criado nesta fase; nada ainda o popula — ver Fase 5
+/// do plano de evolução (Enricher/LLM adapters).
+class Enrichments extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get workItemId => text()();
+  /// summary | translation | classification | entities | suggestion
+  TextColumn get type => text()();
+  TextColumn get content => text()();
+  TextColumn get model => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+}

--- a/lib/infrastructure/repositories/work_item_repository_drift.dart
+++ b/lib/infrastructure/repositories/work_item_repository_drift.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../../domain/repositories/work_item_repository.dart';
+import '../../domain/triage_status.dart';
+import '../../domain/work_item.dart';
+import '../../models/article.dart';
+import '../db/database.dart';
+
+class WorkItemRepositoryDrift implements WorkItemRepository {
+  WorkItemRepositoryDrift(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Stream<List<WorkItem>> watchByStatus(List<TriageStatus> statuses) {
+    final names = statuses.map((s) => s.name).toList();
+    final query = _db.select(_db.workItems)
+      ..where((t) => t.status.isIn(names))
+      ..orderBy([(t) => OrderingTerm.desc(t.ingestedAt)]);
+    return query.watch().map((rows) => rows.map(_toDomain).toList());
+  }
+
+  @override
+  Stream<int> watchCountByStatus(TriageStatus status) {
+    final countExp = _db.workItems.id.count();
+    final query = _db.selectOnly(_db.workItems)
+      ..addColumns([countExp])
+      ..where(_db.workItems.status.equals(status.name));
+    return query.watchSingle().map((row) => row.read(countExp) ?? 0);
+  }
+
+  @override
+  Future<WorkItem?> byId(String id) async {
+    final row = await (_db.select(_db.workItems)..where((t) => t.id.equals(id))).getSingleOrNull();
+    return row == null ? null : _toDomain(row);
+  }
+
+  @override
+  Future<void> upsertFromArticles(List<Article> articles, String providerId) async {
+    if (articles.isEmpty) return;
+    final now = DateTime.now();
+    await _db.batch((batch) {
+      for (final article in articles) {
+        final id = workItemIdFor(providerId, article.id);
+        batch.insert(
+          _db.workItems,
+          WorkItemsCompanion.insert(
+            id: id,
+            providerId: providerId,
+            articleId: article.id,
+            feedId: article.feedId,
+            title: article.title,
+            author: Value(article.author),
+            summary: Value(article.summary),
+            content: Value(article.content),
+            url: Value(article.url),
+            published: Value(article.published),
+            updated: Value(article.updated),
+            isRead: Value(article.isRead),
+            isStarred: Value(article.isStarred),
+            ingestedAt: now,
+            updatedAt: now,
+          ),
+          // status/priority/tagsJson/snoozedUntil/notes/completedAt/
+          // ingestedAt propositalmente omitidos do update: preservam o
+          // valor existente (upsert nunca sobrescreve triagem local).
+          onConflict: DoUpdate(
+            (old) => WorkItemsCompanion(
+              title: Value(article.title),
+              author: Value(article.author),
+              summary: Value(article.summary),
+              content: Value(article.content),
+              url: Value(article.url),
+              published: Value(article.published),
+              updated: Value(article.updated),
+              isRead: Value(article.isRead),
+              isStarred: Value(article.isStarred),
+              updatedAt: Value(now),
+            ),
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  Future<void> save(WorkItem item) async {
+    await _db.into(_db.workItems).insertOnConflictUpdate(_toCompanion(item));
+  }
+
+  @override
+  Future<void> changeStatus(String id, TriageStatus newStatus) async {
+    final current = await byId(id);
+    if (current == null) {
+      throw StateError('WorkItem não encontrado: $id');
+    }
+    if (!isValidTriageTransition(current.status, newStatus)) {
+      throw StateError('Transição inválida: ${current.status} -> $newStatus');
+    }
+    final now = DateTime.now();
+    final isTerminal = newStatus == TriageStatus.concluido || newStatus == TriageStatus.arquivado;
+    await (_db.update(_db.workItems)..where((t) => t.id.equals(id))).write(
+      WorkItemsCompanion(
+        status: Value(newStatus.name),
+        updatedAt: Value(now),
+        completedAt: isTerminal ? Value(current.completedAt ?? now) : const Value(null),
+      ),
+    );
+    await _db.into(_db.workItemEvents).insert(
+          WorkItemEventsCompanion.insert(
+            workItemId: id,
+            timestamp: now,
+            type: 'statusChanged',
+            actor: 'user',
+            payloadJson: Value(jsonEncode({'from': current.status.name, 'to': newStatus.name})),
+          ),
+        );
+  }
+
+  @override
+  Future<int> purgeOlderThan(DateTime cutoff, {List<TriageStatus>? statuses}) async {
+    final targetStatuses = statuses ?? const [TriageStatus.concluido, TriageStatus.arquivado];
+    final names = targetStatuses.map((s) => s.name).toList();
+    return (_db.delete(_db.workItems)
+          ..where((t) => t.status.isIn(names) & t.updatedAt.isSmallerThanValue(cutoff)))
+        .go();
+  }
+
+  @override
+  Future<void> close() => _db.close();
+
+  WorkItem _toDomain(WorkItemRow row) {
+    final tags = (jsonDecode(row.tagsJson) as List).cast<String>();
+    return WorkItem(
+      id: row.id,
+      providerId: row.providerId,
+      articleId: row.articleId,
+      feedId: row.feedId,
+      title: row.title,
+      author: row.author,
+      summary: row.summary,
+      content: row.content,
+      url: row.url,
+      published: row.published,
+      updated: row.updated,
+      status: TriageStatus.fromName(row.status),
+      priority: Priority.fromName(row.priority),
+      tags: tags,
+      isRead: row.isRead,
+      isStarred: row.isStarred,
+      snoozedUntil: row.snoozedUntil,
+      notes: row.notes,
+      ingestedAt: row.ingestedAt,
+      updatedAt: row.updatedAt,
+      completedAt: row.completedAt,
+    );
+  }
+
+  WorkItemsCompanion _toCompanion(WorkItem item) {
+    return WorkItemsCompanion.insert(
+      id: item.id,
+      providerId: item.providerId,
+      articleId: item.articleId,
+      feedId: item.feedId,
+      title: item.title,
+      author: Value(item.author),
+      summary: Value(item.summary),
+      content: Value(item.content),
+      url: Value(item.url),
+      published: Value(item.published),
+      updated: Value(item.updated),
+      status: Value(item.status.name),
+      priority: Value(item.priority.name),
+      tagsJson: Value(jsonEncode(item.tags)),
+      isRead: Value(item.isRead),
+      isStarred: Value(item.isStarred),
+      snoozedUntil: Value(item.snoozedUntil),
+      notes: Value(item.notes),
+      ingestedAt: item.ingestedAt,
+      updatedAt: item.updatedAt,
+      completedAt: Value(item.completedAt),
+    );
+  }
+}

--- a/lib/pages/feed_articles_page.dart
+++ b/lib/pages/feed_articles_page.dart
@@ -3,6 +3,7 @@ import '../providers/feed_provider.dart';
 import '../models/feed.dart';
 import '../models/article.dart';
 import '../services/app_settings.dart';
+import '../infrastructure/db/database_provider.dart';
 import 'article_page.dart';
 
 const _accent = Color(0xFFFF6B2C);
@@ -149,11 +150,27 @@ class _FeedArticlesPageState extends State<FeedArticlesPage>
         loading = false;
       });
       _staggerCtrl.forward(from: 0);
+      _shadowWriteWorkItems(result.articles);
     } catch (e) {
       setState(() {
         error = 'Erro: $e';
         loading = false;
       });
+    }
+  }
+
+  /// Fase 1 da evolução do FeedFlow (docs/EVOLUTION-PLAN.md): grava os
+  /// artigos também no banco local, sem afetar o fluxo visível da tela.
+  /// Fire-and-forget e nunca deve propagar erro para a UI.
+  Future<void> _shadowWriteWorkItems(List<Article> articles) async {
+    if (articles.isEmpty) return;
+    try {
+      if (!await AppSettings.getLocalPersistenceEnabled()) return;
+      final repo = DatabaseProvider.repository;
+      if (repo == null) return;
+      await repo.upsertFromArticles(articles, widget.provider.providerId);
+    } catch (_) {
+      // Shadow-write é best-effort; nunca deve quebrar a leitura de artigos.
     }
   }
 
@@ -172,6 +189,7 @@ class _FeedArticlesPageState extends State<FeedArticlesPage>
         articles.addAll(result.articles);
         _continuation = result.continuation;
       });
+      _shadowWriteWorkItems(result.articles);
     } finally {
       setState(() => _loadingMore = false);
     }

--- a/lib/services/app_settings.dart
+++ b/lib/services/app_settings.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class AppSettings {
   static const _markReadOnScrollKey = 'mark_read_on_scroll';
+  static const _localPersistenceKey = 'local_persistence_shadow_write';
 
   static Future<bool> getMarkReadOnScroll() async {
     final prefs = await SharedPreferences.getInstance();
@@ -11,5 +12,19 @@ class AppSettings {
   static Future<void> setMarkReadOnScroll(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_markReadOnScrollKey, value);
+  }
+
+  /// Fase 1 da evolução do FeedFlow (ver docs/EVOLUTION-PLAN.md): grava os
+  /// artigos carregados também no banco local (`WorkItem`), em paralelo ao
+  /// fluxo normal, sem nenhuma mudança visível na UI ainda. Flag existe para
+  /// permitir desligar rapidamente caso a escrita local cause problema.
+  static Future<bool> getLocalPersistenceEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_localPersistenceKey) ?? true;
+  }
+
+  static Future<void> setLocalPersistenceEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_localPersistenceKey, value);
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_to_front/window_to_front_plugin.h>
 
@@ -18,6 +19,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
   flutter_secure_storage_linux
+  sqlite3_flutter_libs
   url_launcher_linux
   window_to_front
 )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -209,6 +225,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: "540cf382a3bfa99b76e51514db5b0ebcd81ce3679b7c1c9cb9478ff3735e47a1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.28.2"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: "68c138e884527d2bd61df2ade276c3a144df84d1adeb0ab8f3196b5afe021bd4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.28.0"
   fake_async:
     dependency: transitive
     description:
@@ -577,7 +609,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -688,6 +720,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   record_use:
     dependency: transitive
     description:
@@ -813,6 +853,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqlite3:
+    dependency: "direct main"
+    description:
+      name: sqlite3
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: "57090342af1ce32bb499aa641f4ecdd2d6231b9403cea537ac059e803cc20d67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.41.2"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,10 @@ dependencies:
   share_plus: ^10.0.0
   path_provider: ^2.1.0
   workmanager: ^0.9.0+3
+  drift: ^2.20.0
+  sqlite3_flutter_libs: ^0.5.24
+  sqlite3: ^2.4.6
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:
@@ -56,6 +60,7 @@ dev_dependencies:
   freezed: ^2.5.7
   build_runner: ^2.4.13
   json_serializable: ^6.9.0
+  drift_dev: ^2.20.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/domain/work_item_test.dart
+++ b/test/domain/work_item_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feedflow/domain/work_item.dart';
+import 'package:feedflow/domain/triage_status.dart';
+import 'package:feedflow/models/article.dart';
+
+void main() {
+  group('workItemIdFor', () {
+    test('combina providerId e articleId', () {
+      expect(workItemIdFor('feedbin', '123'), 'feedbin:123');
+    });
+  });
+
+  group('WorkItem.fromArticle', () {
+    test('cria WorkItem novo com status novo e campos do snapshot', () {
+      final article = Article(
+        id: 'a1',
+        feedId: 'f1',
+        title: 'Título',
+        author: 'Autor',
+        summary: 'Resumo',
+        content: 'Conteúdo',
+        url: 'https://example.com',
+        isRead: true,
+        isStarred: true,
+      );
+
+      final item = WorkItem.fromArticle(article, 'feedbin');
+
+      expect(item.id, 'feedbin:a1');
+      expect(item.providerId, 'feedbin');
+      expect(item.articleId, 'a1');
+      expect(item.feedId, 'f1');
+      expect(item.title, 'Título');
+      expect(item.status, TriageStatus.novo);
+      expect(item.priority, Priority.none);
+      expect(item.tags, isEmpty);
+      expect(item.isRead, true);
+      expect(item.isStarred, true);
+      expect(item.isActive, true);
+      expect(item.isSnoozed, false);
+    });
+  });
+
+  group('isValidTriageTransition', () {
+    test('permite novo -> triado', () {
+      expect(isValidTriageTransition(TriageStatus.novo, TriageStatus.triado), true);
+    });
+
+    test('permite pular etapas: novo -> arquivado', () {
+      expect(isValidTriageTransition(TriageStatus.novo, TriageStatus.arquivado), true);
+    });
+
+    test('permite transição para o mesmo estado', () {
+      expect(isValidTriageTransition(TriageStatus.triado, TriageStatus.triado), true);
+    });
+
+    test('concluido -> triado é inválida (não está no mapa)', () {
+      expect(isValidTriageTransition(TriageStatus.concluido, TriageStatus.triado), false);
+    });
+
+    test('arquivado -> concluido é inválida', () {
+      expect(isValidTriageTransition(TriageStatus.arquivado, TriageStatus.concluido), false);
+    });
+  });
+
+  group('WorkItem.isActive / isSnoozed', () {
+    test('concluido não é ativo', () {
+      final now = DateTime.now();
+      final item = WorkItem(
+        id: 'x',
+        providerId: 'p',
+        articleId: 'a',
+        feedId: 'f',
+        title: 't',
+        status: TriageStatus.concluido,
+        ingestedAt: now,
+        updatedAt: now,
+      );
+      expect(item.isActive, false);
+    });
+
+    test('snoozedUntil no futuro marca isSnoozed true', () {
+      final now = DateTime.now();
+      final item = WorkItem(
+        id: 'x',
+        providerId: 'p',
+        articleId: 'a',
+        feedId: 'f',
+        title: 't',
+        snoozedUntil: now.add(const Duration(hours: 1)),
+        ingestedAt: now,
+        updatedAt: now,
+      );
+      expect(item.isSnoozed, true);
+    });
+
+    test('snoozedUntil no passado marca isSnoozed false', () {
+      final now = DateTime.now();
+      final item = WorkItem(
+        id: 'x',
+        providerId: 'p',
+        articleId: 'a',
+        feedId: 'f',
+        title: 't',
+        snoozedUntil: now.subtract(const Duration(hours: 1)),
+        ingestedAt: now,
+        updatedAt: now,
+      );
+      expect(item.isSnoozed, false);
+    });
+  });
+}

--- a/test/infrastructure/work_item_repository_drift_test.dart
+++ b/test/infrastructure/work_item_repository_drift_test.dart
@@ -1,0 +1,157 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feedflow/domain/triage_status.dart';
+import 'package:feedflow/domain/work_item.dart';
+import 'package:feedflow/infrastructure/db/database.dart';
+import 'package:feedflow/infrastructure/repositories/work_item_repository_drift.dart';
+import 'package:feedflow/models/article.dart';
+
+void main() {
+  late AppDatabase db;
+  late WorkItemRepositoryDrift repo;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+    repo = WorkItemRepositoryDrift(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Article article({
+    String id = 'a1',
+    String feedId = 'f1',
+    String title = 'Título',
+    bool isRead = false,
+    bool isStarred = false,
+  }) =>
+      Article(id: id, feedId: feedId, title: title, isRead: isRead, isStarred: isStarred);
+
+  group('upsertFromArticles', () {
+    test('cria WorkItems novos com status novo', () async {
+      await repo.upsertFromArticles([article(id: 'a1'), article(id: 'a2')], 'feedbin');
+
+      final item = await repo.byId('feedbin:a1');
+      expect(item, isNotNull);
+      expect(item!.status, TriageStatus.novo);
+      expect(item.providerId, 'feedbin');
+      expect(item.articleId, 'a1');
+
+      final all = await repo.watchByStatus(TriageStatus.values).first;
+      expect(all.length, 2);
+    });
+
+    test('upsert de item existente atualiza snapshot mas preserva status/tags locais', () async {
+      await repo.upsertFromArticles([article(id: 'a1', title: 'Original')], 'feedbin');
+      await repo.changeStatus('feedbin:a1', TriageStatus.triado);
+      await repo.save((await repo.byId('feedbin:a1'))!.copyWith(tags: ['importante']));
+
+      await repo.upsertFromArticles(
+        [article(id: 'a1', title: 'Atualizado', isRead: true)],
+        'feedbin',
+      );
+
+      final item = await repo.byId('feedbin:a1');
+      expect(item!.title, 'Atualizado');
+      expect(item.isRead, true);
+      expect(item.status, TriageStatus.triado, reason: 'status local não deve ser sobrescrito pelo re-sync');
+      expect(item.tags, ['importante'], reason: 'tags locais não devem ser sobrescritas pelo re-sync');
+    });
+
+    test('lista vazia não faz nada', () async {
+      await repo.upsertFromArticles([], 'feedbin');
+      final all = await repo.watchByStatus(TriageStatus.values).first;
+      expect(all, isEmpty);
+    });
+  });
+
+  group('changeStatus', () {
+    test('transição válida atualiza status e completedAt em estado terminal', () async {
+      await repo.upsertFromArticles([article(id: 'a1')], 'feedbin');
+      await repo.changeStatus('feedbin:a1', TriageStatus.concluido);
+
+      final item = await repo.byId('feedbin:a1');
+      expect(item!.status, TriageStatus.concluido);
+      expect(item.completedAt, isNotNull);
+    });
+
+    test('transição inválida lança StateError', () async {
+      await repo.upsertFromArticles([article(id: 'a1')], 'feedbin');
+      await repo.changeStatus('feedbin:a1', TriageStatus.concluido);
+
+      expect(
+        () => repo.changeStatus('feedbin:a1', TriageStatus.triado),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('item inexistente lança StateError', () {
+      expect(
+        () => repo.changeStatus('feedbin:inexistente', TriageStatus.triado),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('watchByStatus / watchCountByStatus', () {
+    test('filtra por status e reage a mudanças', () async {
+      await repo.upsertFromArticles(
+        [article(id: 'a1'), article(id: 'a2'), article(id: 'a3')],
+        'feedbin',
+      );
+      await repo.changeStatus('feedbin:a1', TriageStatus.arquivado);
+
+      final ativos = await repo.watchByStatus([TriageStatus.novo]).first;
+      expect(ativos.length, 2);
+
+      final arquivados = await repo.watchByStatus([TriageStatus.arquivado]).first;
+      expect(arquivados.length, 1);
+      expect(arquivados.single.articleId, 'a1');
+    });
+
+    test('watchCountByStatus retorna contagem correta', () async {
+      await repo.upsertFromArticles([article(id: 'a1'), article(id: 'a2')], 'feedbin');
+      final count = await repo.watchCountByStatus(TriageStatus.novo).first;
+      expect(count, 2);
+    });
+  });
+
+  group('purgeOlderThan', () {
+    test('remove apenas itens terminais mais antigos que o corte', () async {
+      await repo.upsertFromArticles([article(id: 'a1'), article(id: 'a2')], 'feedbin');
+      await repo.changeStatus('feedbin:a1', TriageStatus.arquivado);
+      // a2 continua "novo" — não deve ser removido mesmo sendo "antigo".
+
+      final removed = await repo.purgeOlderThan(DateTime.now().add(const Duration(days: 1)));
+
+      expect(removed, 1);
+      expect(await repo.byId('feedbin:a1'), isNull);
+      expect(await repo.byId('feedbin:a2'), isNotNull);
+    });
+  });
+
+  group('save', () {
+    test('persiste um WorkItem construído manualmente', () async {
+      final now = DateTime.now();
+      final item = WorkItem(
+        id: 'feedbin:manual',
+        providerId: 'feedbin',
+        articleId: 'manual',
+        feedId: 'f1',
+        title: 'Manual',
+        priority: Priority.high,
+        tags: const ['urgente'],
+        ingestedAt: now,
+        updatedAt: now,
+      );
+
+      await repo.save(item);
+
+      final loaded = await repo.byId('feedbin:manual');
+      expect(loaded, isNotNull);
+      expect(loaded!.priority, Priority.high);
+      expect(loaded.tags, ['urgente']);
+    });
+  });
+}


### PR DESCRIPTION
## Resumo

Empilhado sobre #4 (Fase 0). Implementa a Fase 1 do plano de evolução do FeedFlow (`docs/EVOLUTION-PLAN.md`, gerado numa sessão anterior): a fundação de persistência local — pré-requisito para tudo que vem depois (filas, triagem, regras, IA).

### O que muda

- **`lib/domain/`** (novo): `WorkItem` (Freezed, aggregate root do trabalho de triagem — independente do read/unread do provider), `TriageStatus` (FSM enxuta: novo → triado → emAndamento → concluído → arquivado, com `kTriageTransitions` definindo transições válidas e permitindo regras pularem etapas), `Priority`, e a interface `WorkItemRepository` (porta pura, sem SQL).
- **`lib/infrastructure/db/`** (novo): schema drift com 3 tabelas (`work_items`, `work_item_events`, `enrichments` — as duas últimas com schema pronto para as Fases 4/5, ainda não usadas) e `AppDatabase`. **Nativo apenas nesta fase** — `DatabaseProvider.repository` retorna `null` em `kIsWeb`, então a build web não quebra, mas também não ganha a persistência ainda (web/WASM fica para uma iteração futura).
- **`lib/infrastructure/repositories/work_item_repository_drift.dart`** (novo): implementação drift. Ponto importante: `upsertFromArticles` (chamado a cada sync) **nunca sobrescreve** status/tags/priority/notes definidos localmente pelo usuário — só atualiza o snapshot (título, conteúdo, read/star). Testado explicitamente.
- **`feed_articles_page.dart`**: shadow-write — ao carregar artigos, também grava como `WorkItem` no banco local, fire-and-forget, sem nenhuma mudança visível na tela. Atrás de `AppSettings.getLocalPersistenceEnabled()` (default `true`, desligável para rollback rápido sem precisar reverter código).
- **Dependências novas**: `drift`, `sqlite3`, `sqlite3_flutter_libs`, `path` (dev: `drift_dev`).

### Por que shadow-write e não já ligar a UI nova

Seguindo a estratégia de migração incremental do plano: esta fase só prova que a persistência funciona e captura dados reais em paralelo ao fluxo atual. Nenhuma tela lê do banco ainda — isso é a Fase 2 (SyncService + outbox + páginas migradas para leitura local).

## Verificação

- `flutter analyze`: limpo (23 issues pré-existentes, nenhuma nova)
- `flutter test`: **157/157 testes passando** (137 anteriores + 20 novos: FSM de transições, `WorkItem.fromArticle`, e o repositório completo com `NativeDatabase.memory()` — upsert idempotente, preservação de estado local, `changeStatus` com validação de transição, `watchByStatus`/`watchCountByStatus` reativos, `purgeOlderThan`)

## Limitações conhecidas / próximos passos

- Sem suporte web/WASM ainda (guardado via `kIsWeb`, não quebra a build).
- `enrichments`/`work_item_events` têm schema mas nenhum caso de uso ainda (Fases 4/5).
- Build do APK Android não pôde ser validada localmente nesta sessão (ambiente sem "Developer Mode" do Windows habilitado, necessário para symlinks de plugins) — `flutter analyze`/`flutter test` cobrem a verificação disponível.

## Test plan

- [x] `flutter analyze` sem novos erros/warnings
- [x] `flutter test` 100% verde (157/157)
- [ ] Build Android real (bloqueada neste ambiente — ver limitações acima)
- [ ] Confirmar em uso real que o shadow-write não introduz jank perceptível ao rolar a lista de artigos

🤖 Generated with [Claude Code](https://claude.com/claude-code)